### PR TITLE
Update validation logic to make schema type field optional

### DIFF
--- a/@types/swagger-client/index.d.ts
+++ b/@types/swagger-client/index.d.ts
@@ -64,7 +64,7 @@ declare module 'swagger-client' {
   }
 
   export interface SchemaObject {
-    type: 'number' | 'string' | 'object' | 'array';
+    type?: 'number' | 'string' | 'object' | 'array';
     required?: string[];
     items?: SchemaObject;
     properties?: { [property: string]: SchemaObject };

--- a/test/utilities/oas-validator.test.ts
+++ b/test/utilities/oas-validator.test.ts
@@ -164,6 +164,56 @@ describe('OasValidator', () => {
       });
     });
 
+    describe('schema type is not set', () => {
+      const schema: SchemaObject = {
+        description: 'unknown',
+        items: {
+          type: 'number',
+          description: 'a number',
+        },
+        properties: {
+          value: {
+            type: 'string',
+            description: 'a string',
+          },
+        },
+      };
+
+      describe('actual object is a string', () => {
+        it('does nothing', () => {
+          expect(
+            OasValidator.validateObjectAgainstSchema(
+              'This is a string',
+              schema,
+              ['test'],
+            ),
+          ).toBeFalsy();
+        });
+      });
+
+      describe('actual object is an array', () => {
+        it('does nothing', () => {
+          expect(
+            OasValidator.validateObjectAgainstSchema([42, 58], schema, [
+              'test',
+            ]),
+          ).toBeFalsy();
+        });
+      });
+
+      describe('actual object is an object', () => {
+        it('does nothing', () => {
+          expect(
+            OasValidator.validateObjectAgainstSchema(
+              { value: 'this is a string' },
+              schema,
+              ['test'],
+            ),
+          ).toBeFalsy();
+        });
+      });
+    });
+
     describe('schema expects a string', () => {
       const schema: SchemaObject = {
         type: 'string',


### PR DESCRIPTION
This PR is for [API-3879](https://vajira.max.gov/browse/API-3879). It updates response validation logic and the OAS Schema Object type definition to make the type field optional. Also added a few tests.