### PR TITLE
Api 3873/validate parameter types

### DIFF
--- a/@types/swagger-client/index.d.ts
+++ b/@types/swagger-client/index.d.ts
@@ -37,10 +37,11 @@ declare module 'swagger-client' {
     responses: { [responseStatus: string]: Json };
   }
 
-  interface Parameter {
+  export interface Parameter {
     name: string;
     example: Json;
     required: boolean;
+    schema: SchemaObject;
   }
 
   type Api = {

--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -1,10 +1,12 @@
 import { flags } from '@oclif/command';
 import loadJsonFile from 'load-json-file';
 import { ApiKeyCommand } from '../baseCommands';
-import OasSchema, { ParameterExamples } from '../utilities/oas-schema';
 import { Response } from 'swagger-client';
+import OasSchema, { OasParameters } from '../utilities/oas-schema';
 import OasValidator from '../utilities/oas-validator';
 import { DEFAULT_PARAMETER_GROUP } from '../utilities/constants';
+import { WrappedParameterExamples } from '../types/parameter-examples';
+import ParameterWrapper from '../utilities/parameter-wrapper';
 
 export default class Positive extends ApiKeyCommand {
   static description =
@@ -26,6 +28,29 @@ export default class Positive extends ApiKeyCommand {
     },
   ];
 
+  // All of these will be overwritten in the run command
+  private schema: OasSchema = new OasSchema({});
+
+  private validator: OasValidator = new OasValidator(this.schema);
+
+  private operationIds: string[] = [];
+
+  private operationIdToParameters: OasParameters = {};
+
+  private operationIdToResponseAndValidation: {
+    [operationId: string]: {
+      [parameterGroupName: string]: {
+        response?: Response;
+        validationError?: Error;
+      };
+    };
+  } = {};
+
+  private failingOperations: {
+    response?: Response;
+    validationError?: Error;
+  }[] = [];
+
   async run(): Promise<void> {
     const { args, flags } = this.parse(Positive);
     const oasSchemaOptions: ConstructorParameters<typeof OasSchema>[0] = {
@@ -43,123 +68,149 @@ export default class Positive extends ApiKeyCommand {
       oasSchemaOptions.url = args.path;
     }
 
-    const schema = new OasSchema(oasSchemaOptions);
-    const validator = new OasValidator(schema);
+    this.schema = new OasSchema(oasSchemaOptions);
+    this.validator = new OasValidator(this.schema);
 
-    const operationIdToParameters = await schema.getParameters();
-    const operationIds = await schema.getOperationIds();
+    this.operationIdToParameters = await this.schema.getParameters();
+    this.operationIds = await this.schema.getOperationIds();
 
-    const operationIdToResponseAndValidation: {
-      [operationId: string]: {
-        [parameterGroupName: string]: {
-          response?: Response;
-          validationError?: Error;
-        };
-      };
-    } = {};
+    await Promise.all(this.validateParameters());
 
-    await Promise.all(
-      operationIds.flatMap((operationId) => {
-        const parameters = operationIdToParameters[operationId];
+    await Promise.all(this.executeRequests());
 
-        if (Array.isArray(parameters)) {
-          parameters.map((parameterGroup) => {
-            return validator
-              .validateParameters(operationId, parameterGroup)
-              .catch((error) => {
-                operationIdToResponseAndValidation[operationId] = {
-                  validationError: error,
-                };
-              });
-          });
-        } else {
-          return validator
-            .validateParameters(operationId, parameters)
+    await Promise.all(this.validateResponses());
+
+    this.displayResults();
+  }
+
+  validateParameters = (): Promise<void>[] => {
+    return this.operationIds.flatMap((operationId) => {
+      const parameters = this.operationIdToParameters[operationId];
+
+      if (Array.isArray(parameters)) {
+        return parameters.map((parameterGroup) => {
+          return this.validator
+            .validateParameters(operationId, parameterGroup)
             .catch((error) => {
-              operationIdToResponseAndValidation[operationId] = {
+              this.operationIdToResponseAndValidation[operationId] = {};
+              this.operationIdToResponseAndValidation[operationId][
+                Object.keys(parameterGroup)[0]
+              ] = {
                 validationError: error,
               };
             });
-        }
-      }),
-    );
+        });
+      }
+      return this.validator
+        .validateParameters(operationId, parameters)
+        .catch((error) => {
+          this.operationIdToResponseAndValidation[operationId] = {};
+          this.operationIdToResponseAndValidation[operationId][
+            DEFAULT_PARAMETER_GROUP
+          ] = {
+            validationError: error,
+          };
+        });
+    });
+  };
 
-    await Promise.all(
-      operationIds
-        .filter(
-          (operationId) =>
-            !operationIdToResponseAndValidation[operationId]?.validationError,
-        )
-        .flatMap((operationId) => {
-          const operationParameters = operationIdToParameters[operationId];
-
-          // If multiple parameter sets are present (due to example groups), execute once for each
-          if (Array.isArray(operationParameters)) {
-            return operationParameters.map((parameterExamples) => {
-              return this.executeRequest(
-                parameterExamples,
-                schema,
-                operationId,
-              ).then((response) => {
-                const groupName = Object.keys(parameterExamples)[0];
-
-                if (!operationIdToResponseAndValidation[operationId]) {
-                  operationIdToResponseAndValidation[operationId] = {};
-                }
-
-                operationIdToResponseAndValidation[operationId][groupName] = {
-                  response,
-                };
+  validateResponses = (): Promise<void>[] => {
+    return Object.entries(this.operationIdToResponseAndValidation).flatMap(
+      ([operationId, parameterGroups]) => {
+        return Object.entries(parameterGroups)
+          .filter(
+            // This is a bit of wacky typescript to get the following functions to recognize response won't be undefined any more
+            (operation): operation is [string, { response: Response }] =>
+              operation[1].response !== undefined,
+          )
+          .map(([parameterGroupName, { response }]) => {
+            return this.validator
+              .validateResponse(operationId, response)
+              .catch((error) => {
+                this.operationIdToResponseAndValidation[operationId][
+                  parameterGroupName
+                ].validationError = error;
               });
-            });
-          }
+          });
+      },
+    );
+  };
 
-          return this.executeRequest(
-            operationParameters,
-            schema,
-            operationId,
-          ).then((response) => {
-            if (!operationIdToResponseAndValidation[operationId]) {
-              operationIdToResponseAndValidation[operationId] = {};
+  executeRequests = (): Promise<void>[] =>
+    this.operationIds
+      .filter((operationId) => {
+        // filter out all the requests that failed parameter validation
+        const existingValidations = this.operationIdToResponseAndValidation[
+          operationId
+        ];
+
+        return (
+          !existingValidations ||
+          (existingValidations[DEFAULT_PARAMETER_GROUP] &&
+            !existingValidations[DEFAULT_PARAMETER_GROUP].validationError)
+        );
+      })
+      .flatMap((operationId) => {
+        const operationParameters = this.operationIdToParameters[operationId];
+
+        // If multiple parameter sets are present (due to example groups), execute once for each
+        if (Array.isArray(operationParameters)) {
+          return operationParameters
+            .filter((parameterExamples) => {
+              const groupName = Object.keys(parameterExamples)[0];
+              const existingValidations = this
+                .operationIdToResponseAndValidation[operationId];
+
+              return (
+                !existingValidations ||
+                (existingValidations[groupName] &&
+                  !existingValidations[groupName].validationError)
+              );
+            })
+            .map((parameterExamples) => {
+              return this.executeRequest(parameterExamples, operationId).then(
+                (response) => {
+                  const groupName = Object.keys(parameterExamples)[0];
+
+                  if (!this.operationIdToResponseAndValidation[operationId]) {
+                    this.operationIdToResponseAndValidation[operationId] = {};
+                  }
+
+                  this.operationIdToResponseAndValidation[operationId][
+                    groupName
+                  ] = {
+                    response,
+                  };
+                },
+              );
+            });
+        }
+
+        return this.executeRequest(operationParameters, operationId).then(
+          (response) => {
+            if (!this.operationIdToResponseAndValidation[operationId]) {
+              this.operationIdToResponseAndValidation[operationId] = {};
             }
 
-            operationIdToResponseAndValidation[operationId][
+            this.operationIdToResponseAndValidation[operationId][
               DEFAULT_PARAMETER_GROUP
             ] = { response };
-          });
-        }),
+          },
+        );
+      });
+
+  executeRequest = (
+    parameterExamples: WrappedParameterExamples,
+    operationId: string,
+  ): Promise<Response> => {
+    const unwrappedParameters = ParameterWrapper.unwrapParameters(
+      parameterExamples,
     );
+    return this.schema.execute(operationId, unwrappedParameters);
+  };
 
-    await Promise.all(
-      Object.entries(operationIdToResponseAndValidation).map(
-        ([operationId, parameterGroups]) => {
-          return Promise.all(
-            Object.entries(parameterGroups)
-              .filter(
-                // This is a bit of wacky typescript to get the following functions to recognize response won't be undefined any more
-                (operation): operation is [string, { response: Response }] =>
-                  operation[1].response !== undefined,
-              )
-              .map(([parameterGroupName, { response }]) => {
-                return validator
-                  .validateResponse(operationId, response)
-                  .catch((error) => {
-                    operationIdToResponseAndValidation[operationId][
-                      parameterGroupName
-                    ].validationError = error;
-                  });
-              }),
-          );
-        },
-      ),
-    );
-
-    const failingOperations: {
-      response?: Response;
-      validationError?: Error;
-    }[] = [];
-
-    Object.entries(operationIdToResponseAndValidation).forEach(
+  displayResults = (): void => {
+    Object.entries(this.operationIdToResponseAndValidation).forEach(
       ([operationId, parameterGroups]) => {
         Object.entries(parameterGroups).forEach(
           ([parameterGroupName, { response, validationError }]) => {
@@ -172,7 +223,7 @@ export default class Positive extends ApiKeyCommand {
                 }: Succeeded`,
               );
             } else {
-              failingOperations.push({ response, validationError });
+              this.failingOperations.push({ response, validationError });
               this.log(
                 `${operationId}${
                   parameterGroupName === DEFAULT_PARAMETER_GROUP
@@ -188,26 +239,12 @@ export default class Positive extends ApiKeyCommand {
       },
     );
 
-    if (failingOperations.length > 0) {
+    if (this.failingOperations.length > 0) {
       this.error(
-        `${failingOperations.length} operation${
-          failingOperations.length > 1 ? 's' : ''
+        `${this.failingOperations.length} operation${
+          this.failingOperations.length > 1 ? 's' : ''
         } failed`,
       );
     }
-  }
-
-  executeRequest = async (
-    parameterExamples: ParameterExamples,
-    schema: OasSchema,
-    operationId: string,
-  ): Promise<Response> => {
-    if (Object.keys(parameterExamples).length !== 1) {
-      throw new TypeError(
-        `Unexpected parameters format: ${JSON.stringify(parameterExamples)}`,
-      );
-    }
-    const parameters = Object.values(parameterExamples)[0];
-    return schema.execute(operationId, parameters);
   };
 }

--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -85,7 +85,6 @@ export default class Positive extends ApiKeyCommand {
       )
       .flatMap((operationId) => {
         const parameters = this.operationIdToParameters[operationId];
-
         if (Array.isArray(parameters)) {
           return parameters.map((parameterGroup) => {
             return this.validator
@@ -145,8 +144,8 @@ export default class Positive extends ApiKeyCommand {
 
         return (
           !existingValidations ||
-          (existingValidations[DEFAULT_PARAMETER_GROUP] &&
-            !existingValidations[DEFAULT_PARAMETER_GROUP].validationError)
+          !existingValidations[DEFAULT_PARAMETER_GROUP] ||
+          !existingValidations[DEFAULT_PARAMETER_GROUP].validationError
         );
       })
       .flatMap((operationId) => {
@@ -162,8 +161,8 @@ export default class Positive extends ApiKeyCommand {
 
               return (
                 !existingValidations ||
-                (existingValidations[groupName] &&
-                  !existingValidations[groupName].validationError)
+                !existingValidations[groupName] ||
+                !existingValidations[groupName].validationError
               );
             })
             .map((parameterExamples) => {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -6,3 +6,5 @@ export { default as RequiredPropertyError } from './required-property-error';
 export { default as SchemaError } from './schema-error';
 export { default as StatusCodeMismatchError } from './status-code-mismatch-error';
 export { default as TypeMismatchError } from './type-mismatch-error';
+export { default as MissingRequiredParametersError } from './missing-required-parameters-error';
+export { default as InvalidOperationIdError } from './invalid-operation-id-error';

--- a/src/errors/invalid-operation-id-error.ts
+++ b/src/errors/invalid-operation-id-error.ts
@@ -1,0 +1,11 @@
+import { INVALID_OPERATION_ID_ERROR } from '../utilities/constants';
+
+class InvalidOperationIdError extends TypeError {
+  constructor(operationId: string) {
+    super(`${INVALID_OPERATION_ID_ERROR} ${operationId}`);
+
+    Object.setPrototypeOf(this, InvalidOperationIdError.prototype);
+  }
+}
+
+export default InvalidOperationIdError;

--- a/src/errors/missing-required-parameters-error.ts
+++ b/src/errors/missing-required-parameters-error.ts
@@ -1,0 +1,11 @@
+import { MISSING_REQUIRED_PARAMETER_ERROR } from '../utilities/constants';
+
+class MissingRequiredParametersError extends TypeError {
+  constructor(missingParams: string[]) {
+    super(`${MISSING_REQUIRED_PARAMETER_ERROR} [${missingParams}]`);
+
+    Object.setPrototypeOf(this, MissingRequiredParametersError.prototype);
+  }
+}
+
+export default MissingRequiredParametersError;

--- a/src/types/parameter-examples.ts
+++ b/src/types/parameter-examples.ts
@@ -1,0 +1,5 @@
+export type WrappedParameterExamples = {
+  [groupName: string]: ParameterExamples;
+};
+
+export type ParameterExamples = { [name: string]: string | number };

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -18,6 +18,8 @@ export const MISSING_REQUIRED_PROPERTY_ERROR =
   'Actual object missing required property';
 export const NULL_VALUE_ERROR =
   'Actual value is null but schema does not allow null values';
+export const MISSING_REQUIRED_PARAMETER_ERROR = 'Missing required parameters:';
+export const INVALID_OPERATION_ID_ERROR = 'Invalid operationId:';
 
 // error message context prefixes
 export const STATUS_CODE_PREFIX = 'Actual status code:';

--- a/src/utilities/oas-schema.ts
+++ b/src/utilities/oas-schema.ts
@@ -124,6 +124,12 @@ class OasSchema {
     }
     return this.operations;
   };
+
+  getOperation = async (operationId: string): Promise<Method | null> => {
+    const operations = await this.getOperations();
+
+    return operations[operationId] || null;
+  };
 }
 
 export default OasSchema;

--- a/src/utilities/oas-validator.ts
+++ b/src/utilities/oas-validator.ts
@@ -14,7 +14,7 @@ import {
   MissingRequiredParametersError,
   InvalidOperationIdError,
 } from '../errors';
-import OasSchema from './oas-schema';
+import OasSchema, { ParameterExamples } from './oas-schema';
 import {
   NULL_VALUE_ERROR,
   ITEMS_MISSING_ERROR,
@@ -30,7 +30,7 @@ class OasValidator {
 
   validateParameters = async (
     operationId: string,
-    parameters: Json,
+    parameters: ParameterExamples,
   ): Promise<void> => {
     const parameterSchema: {
       [parameterName: string]: Parameter;

--- a/src/utilities/parameter-wrapper.ts
+++ b/src/utilities/parameter-wrapper.ts
@@ -1,0 +1,31 @@
+import {
+  ParameterExamples,
+  WrappedParameterExamples,
+} from '../types/parameter-examples';
+import { DEFAULT_PARAMETER_GROUP } from './constants';
+
+const wrapParameters = (
+  parameters: ParameterExamples,
+  groupName = DEFAULT_PARAMETER_GROUP,
+): WrappedParameterExamples => {
+  const wrappedParameters: WrappedParameterExamples = {};
+  wrappedParameters[groupName] = parameters;
+
+  return wrappedParameters;
+};
+
+const unwrapParameters = (
+  wrappedParameters: WrappedParameterExamples,
+): ParameterExamples => {
+  if (Object.keys(wrappedParameters).length !== 1) {
+    throw new TypeError(
+      `Unexpected parameters format: ${JSON.stringify(wrappedParameters)}`,
+    );
+  }
+  return Object.values(wrappedParameters)[0];
+};
+
+export default {
+  wrapParameters,
+  unwrapParameters,
+};

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -230,16 +230,12 @@ describe('Positive', () => {
             await Positive.run(['http://urldoesnotmatter.com']);
           }).rejects.toThrow('1 operation failed');
 
-          expect(mockExecute).not.toHaveBeenCalledWith('walkIntoMordor', {
-            door: {
-              door: 'front',
-            },
+          expect(mockExecute).toHaveBeenCalledWith('walkIntoMordor', {
+            door: 'front',
           });
 
           expect(mockExecute).not.toHaveBeenCalledWith('walkIntoMordor', {
-            guided: {
-              guide: 'gollum',
-            },
+            guide: 'gollum',
           });
         });
       });

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -1,9 +1,11 @@
 import Positive from '../../src/commands/positive';
+import { InvalidOperationIdError, TypeMismatchError } from '../../src/errors';
 
 const mockGetParameters = jest.fn();
 const mockGetOperationIds = jest.fn();
 const mockExecute = jest.fn();
 const mockValidateResponse = jest.fn();
+const mockValidateParameters = jest.fn();
 
 jest.mock('../../src/utilities/oas-schema', () => {
   return function (): Record<string, jest.Mock> {
@@ -17,6 +19,7 @@ jest.mock('../../src/utilities/oas-schema', () => {
 jest.mock('../../src/utilities/oas-validator', () => {
   return function (): Record<string, jest.Mock> {
     return {
+      validateParameters: mockValidateParameters,
       validateResponse: mockValidateResponse,
     };
   };
@@ -35,6 +38,40 @@ describe('Positive', () => {
     mockGetOperationIds.mockReset();
     mockExecute.mockReset();
     mockValidateResponse.mockReset();
+    mockValidateParameters.mockReset();
+
+    mockGetParameters.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          resolve({
+            walkIntoMordor: {},
+            getHobbit: {},
+            getTomBombadil: {},
+          }),
+        ),
+    );
+    mockGetOperationIds.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          resolve(['walkIntoMordor', 'getHobbit', 'getTomBombadil']),
+        ),
+    );
+    mockExecute.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          resolve({
+            url: 'https://www.lotr.com/walkIntoMorder',
+            status: 400,
+            ok: false,
+          }),
+        ),
+    );
+    mockValidateResponse.mockImplementation(
+      () => new Promise((resolve) => resolve()),
+    );
+    mockValidateParameters.mockImplementation(
+      () => new Promise((resolve) => resolve()),
+    );
   });
 
   describe('API key is not set', () => {
@@ -79,6 +116,64 @@ describe('Positive', () => {
             await Positive.run([...baseCommand, './fixtures/invalid.json']);
           }).rejects.toThrow('unable to load json file');
         });
+      });
+    });
+
+    it('validates the example parameters', async () => {
+      mockGetParameters.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            resolve({
+              walkIntoMordor: {
+                guide: 'gollum',
+              },
+              getHobbit: {
+                name: 'Frodo',
+              },
+              getTomBombadil: {
+                times: 2,
+              },
+            }),
+          ),
+      );
+
+      await Positive.run(['http://urldoesnotmatter.com']);
+
+      expect(mockValidateParameters).toHaveBeenCalledTimes(3);
+      expect(mockValidateParameters).toHaveBeenCalledWith('walkIntoMordor', {
+        guide: 'gollum',
+      });
+      expect(mockValidateParameters).toHaveBeenCalledWith('getHobbit', {
+        name: 'Frodo',
+      });
+      expect(mockValidateParameters).toHaveBeenCalledWith('getTomBombadil', {
+        times: 2,
+      });
+    });
+
+    describe('parameter validation fails', () => {
+      it('outputs a failure for that operation', async () => {
+        mockValidateParameters.mockImplementation(
+          (operationId) =>
+            new Promise((resolve) => {
+              if (operationId === 'walkIntoMordor')
+                throw new TypeMismatchError(
+                  ['parameters', 'guide', 'example'],
+                  'string',
+                  'number',
+                );
+
+              resolve();
+            }),
+        );
+
+        await Positive.run(['http://urldoesnotmatter.com']);
+
+        expect(result).toEqual([
+          'walkIntoMordor: Failed Actual type did not match schema. Path: parameters -> guide. Schema type: string. Actual type: number\n',
+          'getHobbit: Succeeded\n',
+          'getTomBombadil: Failed\n',
+        ]);
       });
     });
 

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -187,17 +187,21 @@ describe('Positive', () => {
               resolve({
                 walkIntoMordor: [
                   {
-                    door: 'front',
+                    door: {
+                      door: 'front',
+                    },
                   },
                   {
-                    guide: 'gollum',
+                    guided: {
+                      guide: 'gollum',
+                    },
                   },
                 ],
                 getHobbit: {
-                  name: 'Frodo',
+                  default: { name: 'Frodo' },
                 },
                 getTomBombadil: {
-                  times: 2,
+                  default: { times: 2 },
                 },
               }),
             ),
@@ -207,11 +211,11 @@ describe('Positive', () => {
       describe('one of the parameter groups fails parameter validation', () => {
         it('does not execute a request for that parameter group', async () => {
           mockValidateParameters.mockImplementation(
-            (operationId, parameters) =>
+            (operationId, wrappedParameters) =>
               new Promise((resolve) => {
                 if (
                   operationId === 'walkIntoMordor' &&
-                  Object.keys(parameters)[0] === 'guide'
+                  Object.keys(wrappedParameters)[0] === 'guided'
                 )
                   throw new TypeMismatchError(
                     ['parameters', 'guide', 'example'],
@@ -227,7 +231,15 @@ describe('Positive', () => {
           }).rejects.toThrow('1 operation failed');
 
           expect(mockExecute).not.toHaveBeenCalledWith('walkIntoMordor', {
-            guide: 'gollum',
+            door: {
+              door: 'front',
+            },
+          });
+
+          expect(mockExecute).not.toHaveBeenCalledWith('walkIntoMordor', {
+            guided: {
+              guide: 'gollum',
+            },
           });
         });
       });
@@ -237,16 +249,24 @@ describe('Positive', () => {
 
         expect(mockValidateParameters).toHaveBeenCalledTimes(4);
         expect(mockValidateParameters).toHaveBeenCalledWith('walkIntoMordor', {
-          door: 'front',
+          door: {
+            door: 'front',
+          },
         });
         expect(mockValidateParameters).toHaveBeenCalledWith('walkIntoMordor', {
-          guide: 'gollum',
+          guided: {
+            guide: 'gollum',
+          },
         });
         expect(mockValidateParameters).toHaveBeenCalledWith('getHobbit', {
-          name: 'Frodo',
+          default: {
+            name: 'Frodo',
+          },
         });
         expect(mockValidateParameters).toHaveBeenCalledWith('getTomBombadil', {
-          times: 2,
+          default: {
+            times: 2,
+          },
         });
       });
 

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -204,7 +204,7 @@ describe('Positive', () => {
         );
       });
 
-      describe('one of the paramter groups failes parameter validation', () => {
+      describe('one of the parameter groups fails parameter validation', () => {
         it('does not execute a request for that parameter group', async () => {
           mockValidateParameters.mockImplementation(
             (operationId, parameters) =>

--- a/test/utilities/oas-validator.test.ts
+++ b/test/utilities/oas-validator.test.ts
@@ -52,11 +52,13 @@ describe('OasValidator', () => {
     });
 
     describe('operation does not exist', () => {
-      it('throws an error', () => {
+      it('throws an error', async () => {
         const schema = generateMockSchema();
         const validator = new OasValidator((schema as unknown) as OasSchema);
-        expect(async () => {
-          await validator.validateParameters('fakeOperationId', {});
+        await expect(async () => {
+          await validator.validateParameters('fakeOperationId', {
+            default: {},
+          });
         }).rejects.toThrow('Invalid operationId: fakeOperationId');
       });
     });
@@ -78,7 +80,7 @@ describe('OasValidator', () => {
 
         expect(async () => {
           await validator.validateParameters('operation1', {
-            name: 'jack',
+            default: { name: 'jack' },
           });
         }).rejects.toThrow('Missing required parameters: [fit]');
       });
@@ -89,9 +91,7 @@ describe('OasValidator', () => {
       const validator = new OasValidator((schema as unknown) as OasSchema);
 
       await validator.validateParameters('operation1', {
-        name: 'james',
-        id: 2,
-        not: 'real',
+        default: { name: 'james', id: 2, not: 'real' },
       });
 
       expect(OasValidator.validateObjectAgainstSchema).toHaveBeenCalledTimes(2);

--- a/test/utilities/oas-validator.test.ts
+++ b/test/utilities/oas-validator.test.ts
@@ -101,7 +101,7 @@ describe('OasValidator', () => {
           type: 'string',
           description: 'blah blah blah',
         },
-        ['parameters', 'name'],
+        ['parameters', 'name', 'example'],
       );
       expect(OasValidator.validateObjectAgainstSchema).toHaveBeenCalledWith(
         2,
@@ -109,7 +109,7 @@ describe('OasValidator', () => {
           type: 'number',
           description: 'blah blah blah',
         },
-        ['parameters', 'id'],
+        ['parameters', 'id', 'example'],
       );
     });
 

--- a/test/utilities/oas-validator.test.ts
+++ b/test/utilities/oas-validator.test.ts
@@ -1,5 +1,5 @@
 import loadJsonFile from 'load-json-file';
-import { Response, SchemaObject } from 'swagger-client';
+import { Response, SchemaObject, Parameter } from 'swagger-client';
 import OasSchema from '../../src/utilities/oas-schema';
 import OasValidator from '../../src/utilities/oas-validator';
 
@@ -10,6 +10,114 @@ describe('OasValidator', () => {
       spec: json,
     });
   };
+
+  describe('validateParameters', () => {
+    const originalValidateObjectAgainstSchema =
+      OasValidator.validateObjectAgainstSchema;
+
+    const generateMockSchema = (
+      additionalParameters: Parameter[] = [],
+    ): OasSchema => {
+      return ({
+        getOperation: jest.fn((operationId) => {
+          if (operationId === 'operation1') {
+            return new Promise((resolve) =>
+              resolve({
+                parameters: [
+                  {
+                    name: 'name',
+                    schema: {
+                      type: 'string',
+                      description: 'blah blah blah',
+                    },
+                  },
+                  {
+                    name: 'id',
+                    schema: {
+                      type: 'number',
+                      description: 'blah blah blah',
+                    },
+                  },
+                  ...additionalParameters,
+                ],
+              }),
+            );
+          }
+        }),
+      } as unknown) as OasSchema;
+    };
+
+    beforeEach(() => {
+      OasValidator.validateObjectAgainstSchema = jest.fn();
+    });
+
+    describe('operation does not exist', () => {
+      it('throws an error', () => {
+        const schema = generateMockSchema();
+        const validator = new OasValidator((schema as unknown) as OasSchema);
+        expect(async () => {
+          await validator.validateParameters('fakeOperationId', {});
+        }).rejects.toThrow('Invalid operationId: fakeOperationId');
+      });
+    });
+
+    describe('input parameters is missing a required parameter', () => {
+      it('throws an error', () => {
+        const schema = generateMockSchema([
+          {
+            name: 'fit',
+            required: true,
+            example: 'tight',
+            schema: {
+              type: 'string',
+              description: 'blah blah blah',
+            },
+          },
+        ]);
+        const validator = new OasValidator((schema as unknown) as OasSchema);
+
+        expect(async () => {
+          await validator.validateParameters('operation1', {
+            name: 'jack',
+          });
+        }).rejects.toThrow('Missing required parameters: [fit]');
+      });
+    });
+
+    it('calls validateObjectAgainstSchema for each valid parameter', async () => {
+      const schema = generateMockSchema();
+      const validator = new OasValidator((schema as unknown) as OasSchema);
+
+      await validator.validateParameters('operation1', {
+        name: 'james',
+        id: 2,
+        not: 'real',
+      });
+
+      expect(OasValidator.validateObjectAgainstSchema).toHaveBeenCalledTimes(2);
+      expect(OasValidator.validateObjectAgainstSchema).toHaveBeenCalledWith(
+        'james',
+        {
+          type: 'string',
+          description: 'blah blah blah',
+        },
+        ['parameters', 'name'],
+      );
+      expect(OasValidator.validateObjectAgainstSchema).toHaveBeenCalledWith(
+        2,
+        {
+          type: 'number',
+          description: 'blah blah blah',
+        },
+        ['parameters', 'id'],
+      );
+    });
+
+    afterEach(() => {
+      OasValidator.validateObjectAgainstSchema = originalValidateObjectAgainstSchema;
+    });
+  });
+
   describe('validateResponse', () => {
     describe('response status code not in OAS', () => {
       it('throws an error', async () => {
@@ -59,13 +167,15 @@ describe('OasValidator', () => {
       });
 
       describe('Response content type is in the OAS', () => {
+        const originalValidateObjectAgainstSchema =
+          OasValidator.validateObjectAgainstSchema;
+        beforeEach(() => {
+          OasValidator.validateObjectAgainstSchema = jest.fn();
+        });
         it('calls validateObjectAgainstSchema with the response body', async () => {
           const filePath = 'test/fixtures/simple_forms_oas.json';
           const schema = await generateSchema(filePath);
           const validator = new OasValidator(schema);
-          const originalValidateObjectAgainstSchema =
-            OasValidator.validateObjectAgainstSchema;
-          OasValidator.validateObjectAgainstSchema = jest.fn();
 
           const response: Response = {
             ok: false,
@@ -93,6 +203,8 @@ describe('OasValidator', () => {
             },
             ['body'],
           );
+        });
+        afterEach(() => {
           OasValidator.validateObjectAgainstSchema = originalValidateObjectAgainstSchema;
         });
       });
@@ -100,8 +212,9 @@ describe('OasValidator', () => {
   });
 
   describe('validateObjectAgainstSchema', () => {
-    const validateSpy = jest.spyOn(OasValidator, 'validateObjectAgainstSchema');
+    let validateSpy;
     beforeEach(() => {
+      validateSpy = jest.spyOn(OasValidator, 'validateObjectAgainstSchema');
       validateSpy.mockClear();
     });
 

--- a/test/utilities/parameter-wrapper.test.ts
+++ b/test/utilities/parameter-wrapper.test.ts
@@ -1,0 +1,68 @@
+import ParameterWrapper from '../../src/utilities/parameter-wrapper';
+
+describe('ParameterWrapper', () => {
+  describe('unwrapParameters', () => {
+    describe('unexpected parameters format', () => {
+      it('throws an error', () => {
+        const parameterExamples = {
+          where: {
+            door: 'front',
+          },
+          who: {
+            guide: 'gollum',
+          },
+        };
+
+        expect(() => {
+          ParameterWrapper.unwrapParameters(parameterExamples);
+        }).toThrow(
+          `Unexpected parameters format: ${JSON.stringify(parameterExamples)}`,
+        );
+      });
+    });
+
+    it('removes the grouping from the parameters', () => {
+      expect(
+        ParameterWrapper.unwrapParameters({
+          groupName: {
+            foo: 'bar',
+          },
+        }),
+      ).toEqual({
+        foo: 'bar',
+      });
+    });
+  });
+
+  describe('wrapParameters', () => {
+    describe('no group name is provided', () => {
+      it('wraps it with the default group name', () => {
+        expect(
+          ParameterWrapper.wrapParameters({
+            foo: 'bar',
+          }),
+        ).toEqual({
+          default: {
+            foo: 'bar',
+          },
+        });
+      });
+    });
+    describe('group name is provided', () => {
+      it('wraps it with the given group name', () => {
+        expect(
+          ParameterWrapper.wrapParameters(
+            {
+              foo: 'bar',
+            },
+            'testGroup',
+          ),
+        ).toEqual({
+          testGroup: {
+            foo: 'bar',
+          },
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds validation to example parameters. It also filters out any parameters that failed validation from the execution block to prevent unnecessary calls (and prevent us from overwriting the failure).

In addition I've done some refactoring to separate logic out into smaller methods to reduce cognitive overhead.