### PR TITLE
Convert to async/await where possible

### DIFF
--- a/src/utilities/oas-schema.ts
+++ b/src/utilities/oas-schema.ts
@@ -14,7 +14,7 @@ type OasOperations = {
   [operationId: string]: Method;
 };
 
-class OasSchema {
+class OASSchema {
   private _client: Promise<Swagger>;
 
   private operations: OasOperations = {};
@@ -131,4 +131,4 @@ class OasSchema {
   };
 }
 
-export default OasSchema;
+export default OASSchema;

--- a/src/utilities/oas-validator.ts
+++ b/src/utilities/oas-validator.ts
@@ -23,7 +23,7 @@ import {
 import { ParameterExamples } from '../types/parameter-examples';
 import ValidationFailure from '../validation-failures/validation-failure';
 
-class OasValidator {
+class OASValidator {
   private schema: OasSchema;
 
   constructor(schema: OasSchema) {
@@ -67,7 +67,7 @@ class OasValidator {
       if (Object.keys(parameterSchema).includes(key)) {
         failures = [
           ...failures,
-          ...OasValidator.validateObjectAgainstSchema(
+          ...OASValidator.validateObjectAgainstSchema(
             value,
             parameterSchema[key].schema,
             ['parameters', key, 'example'],
@@ -101,7 +101,7 @@ class OasValidator {
       return [new ContentTypeMismatch(contentType)];
     }
 
-    return OasValidator.validateObjectAgainstSchema(
+    return OASValidator.validateObjectAgainstSchema(
       response.body,
       contentTypeSchema.schema,
       ['body'],
@@ -216,4 +216,4 @@ class OasValidator {
   }
 }
 
-export default OasValidator;
+export default OASValidator;

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -342,7 +342,7 @@ describe('Positive', () => {
             new Promise((resolve) => resolve(['walkIntoMordor', 'getHobbit'])),
         );
         mockValidateResponse.mockImplementation(
-          () => new Promise((resolve) => resolve()),
+          () => new Promise((resolve) => resolve([])),
         );
         mockValidateResponse.mockImplementation(
           () =>
@@ -450,7 +450,7 @@ describe('Positive', () => {
           ),
         );
       mockValidateResponse.mockImplementation(
-        () => new Promise((resolve) => resolve()),
+        () => new Promise((resolve) => resolve([])),
       );
 
       await expect(async () => {


### PR DESCRIPTION
This was a fairly simple update. Anywhere `map` was used we could make the change, but anywhere `flatMap` was used we couldn't.