### PR TITLE
fix custom jest matcher to be recognized

### DIFF
--- a/@types/swagger-client/index.d.ts
+++ b/@types/swagger-client/index.d.ts
@@ -15,7 +15,7 @@ declare module 'swagger-client' {
     paths: { [path: string]: Path };
   }
 
-  interface Response {
+  export interface Response {
     ok: boolean;
     status: number;
     url: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2019",
-    "lib": ["es2020"],
-    "module": "commonjs",
+    "target": "ES2019",
+    "lib": ["ES2020"],
+    "module": "CommonJS",
     "outDir": "lib",
     "strict": true,
     "noImplicitAny": false,
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "downlevelIteration": true,
     "resolveJsonModule": true,
-    "typeRoots": ["./@types", "./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types", "@types"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "@types/**/*"],
 }


### PR DESCRIPTION
This pr supports [API-4324](https://vajira.max.gov/browse/API-4324) by fixing the tsconfig to correctly recognize the custom matcher we made for jest.

Running `npm run test` produces no errors.