### PR TITLE
Setup semantic release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
         withCredentials([
           usernamePassword(
             credentialsId: 'GITHUB_USERNAME_TOKEN',
-            usernameVariable: 'GITHUB_USERNAME'
+            usernameVariable: 'GITHUB_USERNAME',
             passwordVariable: 'GITHUB_TOKEN'), 
           string(
             credentialsId: 'LIGHTHOUSE_NPM_REGISTRY_PROXY_NEXUS_TOKEN',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,4 +44,10 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      // Clean up file containing secrets
+      sh 'rm -rf .npmrc'
+    }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     }
   }
   environment {
+    NPM_TOKEN = credentials('LIGHTHOUSE_NPM_REGISTRY_PROXY_NEXUS_TOKEN')
     NPM_CONFIG_REGISTRY = 'https://tools.health.dev-developer.va.gov/nexus/repository/lighthouse-npm-registry-proxy/'
   }
 
@@ -35,10 +36,7 @@ pipeline {
           usernamePassword(
             credentialsId: 'GITHUB_USERNAME_TOKEN',
             usernameVariable: 'GITHUB_USERNAME',
-            passwordVariable: 'GITHUB_TOKEN'), 
-          string(
-            credentialsId: 'LIGHTHOUSE_NPM_REGISTRY_PROXY_NEXUS_TOKEN',
-            variable: 'NPM_TOKEN')
+            passwordVariable: 'GITHUB_TOKEN')
         ]) {
           sh 'npm run release'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'vasdvp/lighthouse-node-application-base:node12'
+      image 'vasdvp/lighthouse-node-application-base:node14'
     }
   }
   environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,9 @@ pipeline {
       image 'vasdvp/lighthouse-node-application-base:node12'
     }
   }
+  environment {
+    NPM_CONFIG_REGISTRY = 'https://tools.health.dev-developer.va.gov/nexus/repository/lighthouse-npm-registry-proxy/'
+  }
 
   stages {
     stage('Setup') {
@@ -31,6 +34,7 @@ pipeline {
         withCredentials([
           usernamePassword(
             credentialsId: 'GITHUB_USERNAME_TOKEN',
+            usernameVariable: 'GITHUB_USERNAME'
             passwordVariable: 'GITHUB_TOKEN'), 
           string(
             credentialsId: 'LIGHTHOUSE_NPM_REGISTRY_PROXY_NEXUS_TOKEN',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
+        sh 'echo registry = $NPM_CONFIG_REGISTRY\n_auth = $NPM_TOKEN > .npmrc'
         sh 'npm install'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,5 +26,19 @@ pipeline {
         sh 'npm run build'
       }
     }
+    stage('Release') {
+      steps {
+        withCredentials([
+          usernamePassword(
+            credentialsId: 'GITHUB_USERNAME_TOKEN',
+            passwordVariable: 'GITHUB_TOKEN'), 
+          string(
+            credentialsId: 'LIGHTHOUSE_NPM_REGISTRY_PROXY_NEXUS_TOKEN',
+            variable: 'NPM_TOKEN')
+        ]) {
+          sh 'npm run release'
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,10 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
-        sh 'cat > .npmrc << EOL
+        sh 'echo """
         registry = $NPM_CONFIG_REGISTRY
-        _auth = $NPM_TOKEN 
-        EOL > .npmrc'
+        _auth = $NPM_TOKEN
+        """ > .npmrc'
         sh 'npm install'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,10 +12,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
-        sh 'echo """
-        registry = $NPM_CONFIG_REGISTRY
-        _auth = $NPM_TOKEN
-        """ > .npmrc'
+        sh 'echo """registry = $NPM_CONFIG_REGISTRY\n_auth = $NPM_TOKEN""" > .npmrc'
         sh 'npm install'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,10 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
-        sh 'echo registry = $NPM_CONFIG_REGISTRY\n_auth = $NPM_TOKEN > .npmrc'
+        sh 'cat > .npmrc << EOL
+        registry = $NPM_CONFIG_REGISTRY
+        _auth = $NPM_TOKEN 
+        EOL > .npmrc'
         sh 'npm install'
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loast",
   "description": "CLI for testing Lighthouse APIs using OpenAPI specs",
-  "version": "0.2.0",
+  "version": "0.0.0-development",
   "bin": {
     "loast": "./bin/run"
   },
@@ -32,7 +32,8 @@
     "jest-junit-reporter": "^1.1.0",
     "prettier": "^2.1.2",
     "ts-jest": "^26.4.4",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "semantic-release": "^17.4.1"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -68,7 +69,8 @@
     "test:watch": "jest --watchAll",
     "version": "oclif-dev readme && git add README.md",
     "lint": "eslint . --ext .ts --config .eslintrc.js",
-    "lint:fix": "eslint . --ext .ts --config .eslintrc.js --fix"
+    "lint:fix": "eslint . --ext .ts --config .eslintrc.js --fix",
+    "release": "semantic-release"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
[API-4326](https://vajira.max.gov/browse/API-4326)

This adds [semantic-release](https://github.com/semantic-release/semantic-release) as part of our CI/CD pipeline. With this in place, any build on master will check to see if a new version needs to be released. If so, it will build and release it as well as push the git tags and release back to the repo.

semantic-release uses [formatted commit messages](https://github.com/semantic-release/semantic-release#commit-message-format) to determine when a new release is needed. We have a [follow-up ticket](https://vajira.max.gov/browse/API-4912) to determine and enforce how we want to make these formatted message into our workflow, so for now we won't have a release version.