### PR TITLE
Update failure message for property mismatch validation failure

### DIFF
--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -201,16 +201,23 @@ abstract class BaseValidator {
 
     const actualProperties = Object.keys(actual);
     const expectedProperties = Object.keys(properties);
+    const unexpectedActualProperties = actualProperties.filter(
+      (property) => !expectedProperties.includes(property),
+    );
 
     // check that the actual object only contains properties present in expected object
-    if (
-      actualProperties.filter(
-        (property) => !expectedProperties.includes(property),
-      ).length > 0
-    ) {
+    if (unexpectedActualProperties.length > 0) {
+      const expectedPropertiesNotFound = expectedProperties.filter(
+        (property) => !actualProperties.includes(property),
+      );
+
       this._failures = [
         ...this._failures,
-        new PropertiesMismatch([...path], expectedProperties, actualProperties),
+        new PropertiesMismatch(
+          [...path],
+          expectedPropertiesNotFound,
+          unexpectedActualProperties,
+        ),
       ];
     }
 

--- a/src/validation-messages/failures/properties-mismatch.ts
+++ b/src/validation-messages/failures/properties-mismatch.ts
@@ -6,12 +6,17 @@ class PropertiesMismatch extends ValidationFailure {
     schemaProperties: string[],
     actualProperties: string[],
   ) {
-    super(
-      `Actual object contains a property not present in schema. Schema properties: ${schemaProperties.join(
-        ', ',
-      )}. Actual properties: ${actualProperties.join(', ')}.`,
-      path,
-    );
+    let message = `Actual object contains a property not present in schema. Actual properties not expected: ${actualProperties.join(
+      ', ',
+    )}.`;
+
+    if (schemaProperties.length > 0) {
+      message = message.concat(
+        ` Schema properties not found: ${schemaProperties.join(', ')}.`,
+      );
+    }
+
+    super(message, path);
   }
 }
 

--- a/src/validation-messages/failures/properties-mismatch.ts
+++ b/src/validation-messages/failures/properties-mismatch.ts
@@ -3,16 +3,16 @@ import ValidationFailure from './validation-failure';
 class PropertiesMismatch extends ValidationFailure {
   constructor(
     path: string[],
-    schemaProperties: string[],
-    actualProperties: string[],
+    schemaPropertiesNotFound: string[],
+    unexpectedActualProperties: string[],
   ) {
-    let message = `Actual object contains a property not present in schema. Actual properties not expected: ${actualProperties.join(
+    let message = `Actual object contains a property not present in schema. Actual properties not expected: ${unexpectedActualProperties.join(
       ', ',
     )}.`;
 
-    if (schemaProperties.length > 0) {
+    if (schemaPropertiesNotFound.length > 0) {
       message = message.concat(
-        ` Schema properties not found: ${schemaProperties.join(', ')}.`,
+        ` Schema properties not found: ${schemaPropertiesNotFound.join(', ')}.`,
       );
     }
 

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -621,19 +621,40 @@ describe('BaseValidator', () => {
           let tempSchema;
           beforeAll(() => {
             tempSchema = { ...schema };
-            tempSchema.properties = { ...schema.properties };
+            tempSchema.properties = {
+              ...schema.properties,
+              house: {
+                type: 'string',
+                description: 'gryffindor, hufflepuff, slytherin, ravenclaw',
+              },
+            };
             tempSchema.required = ['value'];
           });
 
-          it('adds a validation failure', () => {
-            validator.validateObjectAgainstSchema(
-              { fake: 'property', value: 'potato' },
-              tempSchema,
-              ['body', 'form'],
-            );
-            expect(validator.failures).toContainValidationFailure(
-              'Actual object contains a property not present in schema. Schema properties: value. Actual properties: fake, value. Path: body -> form',
-            );
+          describe('all schema properties are present', () => {
+            it('failure message contains only actual properties that were not expected', () => {
+              validator.validateObjectAgainstSchema(
+                { fake: 'property', value: 'potato', house: 'slytherin' },
+                tempSchema,
+                ['body', 'form'],
+              );
+              expect(validator.failures).toContainValidationFailure(
+                'Actual object contains a property not present in schema. Actual properties not expected: fake. Path: body -> form',
+              );
+            });
+          });
+
+          describe('not all schema properties are present', () => {
+            it('failure message contains all properties that did not match', () => {
+              validator.validateObjectAgainstSchema(
+                { fake: 'property', value: 'potato' },
+                tempSchema,
+                ['body', 'form'],
+              );
+              expect(validator.failures).toContainValidationFailure(
+                'Actual object contains a property not present in schema. Actual properties not expected: fake. Schema properties not found: house. Path: body -> form',
+              );
+            });
           });
         });
 


### PR DESCRIPTION
This PR is for [API-6202](https://vajira.max.gov/browse/API-6202). It updates the failure message for object property mismatch failures so that only properties that did not match will be displayed instead of displaying all schema properties.