### PR TITLE
Add check for missing optional parameters

### DIFF
--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -13,6 +13,7 @@ import {
 } from '../../validation-messages/failures';
 import {
   EmptyArray,
+  MissingProperties,
   ValidationWarning,
 } from '../../validation-messages/warnings';
 
@@ -223,6 +224,17 @@ abstract class BaseValidator {
         ];
       }
     });
+
+    const missingOptionalProperties = expectedProperties.filter(
+      (property) => !actualProperties.includes(property),
+    );
+
+    if (missingOptionalProperties.length > 0) {
+      this._warnings = [
+        ...this._warnings,
+        new MissingProperties(missingOptionalProperties, path),
+      ];
+    }
 
     // re-un for each property that has a schema present
     Object.entries(actual)

--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -225,7 +225,11 @@ abstract class BaseValidator {
       }
     });
 
-    const missingOptionalProperties = expectedProperties.filter(
+    const optionalProperties = expectedProperties.filter(
+      (property) => !expected.required?.includes(property),
+    );
+
+    const missingOptionalProperties = optionalProperties.filter(
       (property) => !actualProperties.includes(property),
     );
 

--- a/src/validation-messages/warnings/index.ts
+++ b/src/validation-messages/warnings/index.ts
@@ -1,2 +1,3 @@
 export { default as ValidationWarning } from './validation-warning';
 export { default as EmptyArray } from './empty-array';
+export { default as MissingProperties } from './missing-properties';

--- a/src/validation-messages/warnings/missing-properties.ts
+++ b/src/validation-messages/warnings/missing-properties.ts
@@ -1,0 +1,14 @@
+import ValidationWarning from './validation-warning';
+
+class MissingProperties extends ValidationWarning {
+  constructor(missingParameters, path) {
+    super(
+      `This object is missing non-required parameters that were unable to be validated, including ${missingParameters.join(
+        ', ',
+      )}.`,
+      path,
+    );
+  }
+}
+
+export default MissingProperties;

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -55,7 +55,9 @@ describe('Positive', () => {
       url: 'https://www.lotr.com/walkIntoMorder',
       status: 200,
       ok: true,
-      body: {},
+      body: {
+        data: ['test'],
+      },
       headers: {
         'content-type': 'application/json',
       },
@@ -492,7 +494,7 @@ describe('Positive', () => {
       ]);
     });
 
-    it('outputs a warning when present', async () => {
+    it('outputs any present warnings', async () => {
       const operation = new OASOperation({
         operationId: 'getHobbit',
         responses: {

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -674,12 +674,26 @@ describe('BaseValidator', () => {
           );
         });
 
-        it('adds a warning when a property cannot be validated', () => {
+        it('adds a warning when an optional property cannot be validated', () => {
           validator.validateObjectAgainstSchema({}, schema, ['body', 'form']);
 
           const warnings = validator.warnings;
           expect(warnings).toHaveLength(1);
           expect(warnings).toContainValidationWarning(
+            'Warning: This object is missing non-required parameters that were unable to be validated, including value. Path: body -> form',
+          );
+        });
+
+        it('does not print out the missing property warning when only required properties are missing', () => {
+          validator.validateObjectAgainstSchema(
+            {},
+            { ...schema, required: ['value'] },
+            ['body', 'form'],
+          );
+
+          const warnings = validator.warnings;
+          expect(warnings).toHaveLength(0);
+          expect(warnings).not.toContainValidationWarning(
             'Warning: This object is missing non-required parameters that were unable to be validated, including value. Path: body -> form',
           );
         });

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -658,22 +658,30 @@ describe('BaseValidator', () => {
           });
         });
 
-        describe('object has properties', () => {
-          it('validates the properties', () => {
-            validator.validateObjectAgainstSchema(
-              {
-                value: 42,
-              },
-              schema,
-              ['body', 'form'],
-            );
+        it('validates the properties when object has properties', () => {
+          validator.validateObjectAgainstSchema(
+            {
+              value: 42,
+            },
+            schema,
+            ['body', 'form'],
+          );
 
-            const failures = validator.failures;
-            expect(failures).toHaveLength(1);
-            expect(validator.failures).toContainValidationFailure(
-              'Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> form -> value',
-            );
-          });
+          const failures = validator.failures;
+          expect(failures).toHaveLength(1);
+          expect(failures).toContainValidationFailure(
+            'Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> form -> value',
+          );
+        });
+
+        it('adds a warning when a property cannot be validated', () => {
+          validator.validateObjectAgainstSchema({}, schema, ['body', 'form']);
+
+          const warnings = validator.warnings;
+          expect(warnings).toHaveLength(1);
+          expect(warnings).toContainValidationWarning(
+            'Warning: This object is missing non-required parameters that were unable to be validated, including value. Path: body -> form',
+          );
         });
 
         describe('schema expects an enum', () => {


### PR DESCRIPTION
[API-5845](https://vajira.max.gov/browse/API-5845)

This updates the schema validation to include a warning when there are properties on an object schema that were not included in the actual response.