### PR TITLE
Merge example and examples values into the default example group

### DIFF
--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -1,7 +1,6 @@
 import { flags } from '@oclif/command';
 import loadJsonFile from 'load-json-file';
 import { ApiKeyCommand } from '../baseCommands';
-import { DEFAULT_PARAMETER_GROUP } from '../utilities/constants';
 import OASSchema from '../utilities/oas-schema';
 import { InvalidResponse } from '../validation-messages/failures';
 import { ParameterValidator, ResponseValidator } from '../utilities/validators';

--- a/test/utilities/example-group.factory.test.ts
+++ b/test/utilities/example-group.factory.test.ts
@@ -3,214 +3,311 @@ import OASOperation from '../../src/utilities/oas-operation';
 
 describe('ExampleGroupFactory', () => {
   describe('getExampleGroups', () => {
-    it('returns examples in the default group when no groups are present', () => {
-      const operation = new OASOperation({
-        operationId: '123',
-        responses: {},
-        parameters: [
-          {
-            name: 'age',
-            in: 'query',
-            required: true,
-            example: 111,
-            schema: {
-              type: 'integer',
-              description: 'a number',
-            },
-          },
-          {
-            name: 'family',
-            in: 'query',
-            required: true,
-            example: 'baggins',
-            schema: {
-              type: 'string',
-              description: 'a string',
-            },
-          },
-        ],
-      });
-      const groups = ExampleGroupFactory.buildFromOperation(operation);
+    let ageParameter;
 
-      expect(groups).toHaveLength(1);
-      const defaultGroup = groups[0];
-      expect(defaultGroup.name).toEqual('default');
-      expect(defaultGroup.examples).toEqual({
-        age: 111,
-        family: 'baggins',
+    beforeEach(() => {
+      ageParameter = {
+        name: 'age',
+        in: 'query',
+        required: true,
+        example: 111,
+        schema: {
+          type: 'integer',
+          description: 'a number',
+        },
+      };
+    });
+
+    describe('the examples field is not set', () => {
+      let familyParameter;
+
+      beforeEach(() => {
+        familyParameter = {
+          name: 'family',
+          in: 'query',
+          example: 'baggins',
+          schema: {
+            type: 'string',
+            description: 'a string',
+          },
+        };
+      });
+
+      it('returns examples in the default group', () => {
+        familyParameter.required = true;
+
+        const operation = new OASOperation({
+          operationId: '123',
+          responses: {},
+          parameters: [ageParameter, familyParameter],
+        });
+        const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+        expect(groups).toHaveLength(1);
+        const defaultGroup = groups[0];
+        expect(defaultGroup.name).toEqual('default');
+        expect(defaultGroup.examples).toEqual({
+          age: 111,
+          family: 'baggins',
+        });
+      });
+
+      it('non-required parameter examples are merged into the default group when example is set', () => {
+        const operation = new OASOperation({
+          operationId: '123',
+          responses: {},
+          parameters: [ageParameter, familyParameter],
+        });
+        const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+        expect(groups).toHaveLength(1);
+        const defaultGroup = groups[0];
+        expect(defaultGroup.examples).toEqual({
+          age: 111,
+          family: 'baggins',
+        });
       });
     });
 
-    it('does not return non-required values', () => {
-      const operation = new OASOperation({
-        operationId: '123',
-        responses: {},
-        parameters: [
-          {
-            name: 'age',
+    describe('the examples field is set', () => {
+      let familyParameter;
+
+      beforeEach(() => {
+        familyParameter = {
+          name: 'family',
+          in: 'query',
+          examples: {
+            personal: {
+              value: 'baggins',
+            },
+          },
+          schema: {
+            type: 'string',
+            description: 'a string',
+          },
+        };
+      });
+
+      describe('no default key', () => {
+        it('returns grouped parameters', () => {
+          ageParameter.required = false;
+          ageParameter.examples = {
+            personal: {
+              value: 111,
+            },
+          };
+          delete ageParameter.example;
+
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(2);
+          const group = groups[0];
+          expect(group.name).toEqual('personal');
+          expect(group.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+          });
+
+          const defaultGroup = groups[1];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({});
+        });
+
+        it('includes required examples in all groups', () => {
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(2);
+          const group = groups[0];
+          expect(group.name).toEqual('personal');
+          expect(group.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+          });
+
+          const defaultGroup = groups[1];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({
+            age: 111,
+          });
+        });
+
+        it('returns all groups present', () => {
+          familyParameter.examples = {
+            personal: {
+              value: 'baggins',
+            },
+            temporary: {
+              value: 'underhill',
+            },
+          };
+
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(3);
+          const firstGroup = groups[0];
+          expect(firstGroup.name).toEqual('personal');
+          expect(firstGroup.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+          });
+          const secondGroup = groups[1];
+          expect(secondGroup.name).toEqual('temporary');
+          expect(secondGroup.examples).toEqual({
+            age: 111,
+            family: 'underhill',
+          });
+          const defaultGroup = groups[2];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({
+            age: 111,
+          });
+        });
+
+        it('does not merge required parameters without the default key', () => {
+          familyParameter.required = true;
+
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(2);
+          const group = groups[0];
+          expect(group.name).toEqual('personal');
+          expect(group.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+          });
+
+          const defaultGroup = groups[1];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({
+            age: 111,
+            family: undefined,
+          });
+        });
+      });
+
+      describe('default key is present', () => {
+        let actorParameter;
+
+        beforeEach(() => {
+          actorParameter = {
+            name: 'actor',
             in: 'query',
             required: true,
-            example: 111,
-            schema: {
-              type: 'integer',
-              description: 'a number',
-            },
-          },
-          {
-            name: 'family',
-            in: 'query',
-            required: false,
-            example: 'baggins',
-            schema: {
-              type: 'string',
-              description: 'a string',
-            },
-          },
-        ],
-      });
-      const groups = ExampleGroupFactory.buildFromOperation(operation);
-
-      expect(groups).toHaveLength(1);
-      const defaultGroup = groups[0];
-      expect(defaultGroup.examples).toEqual({
-        age: 111,
-      });
-    });
-
-    it('returns grouped parameters', () => {
-      const operation = new OASOperation({
-        operationId: '123',
-        responses: {},
-        parameters: [
-          {
-            name: 'age',
-            in: 'query',
             examples: {
-              personal: {
-                value: 111,
-              },
-            },
-            schema: {
-              type: 'integer',
-              description: 'a number',
-            },
-          },
-          {
-            name: 'family',
-            in: 'query',
-            examples: {
-              personal: {
-                value: 'baggins',
-              },
-            },
-            schema: {
-              type: 'string',
-              description: 'a string',
-            },
-          },
-        ],
-      });
-      const groups = ExampleGroupFactory.buildFromOperation(operation);
-
-      expect(groups).toHaveLength(2);
-      const group = groups[0];
-      expect(group.name).toEqual('personal');
-      expect(group.examples).toEqual({
-        age: 111,
-        family: 'baggins',
-      });
-    });
-
-    it('includes all required examples in any groups', () => {
-      const operation = new OASOperation({
-        operationId: '123',
-        responses: {},
-        parameters: [
-          {
-            name: 'age',
-            in: 'query',
-            required: true,
-            example: 111,
-            schema: {
-              type: 'integer',
-              description: 'a number',
-            },
-          },
-          {
-            name: 'family',
-            in: 'query',
-            required: false,
-            examples: {
-              personal: {
-                value: 'baggins',
-              },
-            },
-            schema: {
-              type: 'string',
-              description: 'a string',
-            },
-          },
-        ],
-      });
-      const groups = ExampleGroupFactory.buildFromOperation(operation);
-
-      expect(groups).toHaveLength(2);
-      const group = groups[0];
-      expect(group.name).toEqual('personal');
-      expect(group.examples).toEqual({
-        age: 111,
-        family: 'baggins',
-      });
-    });
-
-    it('returns all groups present', () => {
-      const operation = new OASOperation({
-        operationId: '123',
-        responses: {},
-        parameters: [
-          {
-            name: 'age',
-            in: 'query',
-            required: true,
-            example: 111,
-            schema: {
-              type: 'integer',
-              description: 'a number',
-            },
-          },
-          {
-            name: 'family',
-            in: 'query',
-            required: false,
-            examples: {
-              personal: {
-                value: 'baggins',
+              default: {
+                value: 'Ian Holm',
               },
               temporary: {
-                value: 'underhill',
+                value: 'Martin Freeman',
               },
             },
             schema: {
               type: 'string',
               description: 'a string',
             },
-          },
-        ],
-      });
-      const groups = ExampleGroupFactory.buildFromOperation(operation);
+          };
+        });
 
-      expect(groups).toHaveLength(3);
-      const firstGroup = groups[0];
-      expect(firstGroup.name).toEqual('personal');
-      expect(firstGroup.examples).toEqual({
-        age: 111,
-        family: 'baggins',
-      });
-      const secondGroup = groups[1];
-      expect(secondGroup.name).toEqual('temporary');
-      expect(secondGroup.examples).toEqual({
-        age: 111,
-        family: 'underhill',
+        it('merges required examples with default key into all groups', () => {
+          familyParameter.examples = {
+            personal: {
+              value: 'baggins',
+            },
+            temporary: {
+              value: 'underhill',
+            },
+          };
+
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter, actorParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(3);
+          const firstGroup = groups[0];
+          expect(firstGroup.name).toEqual('personal');
+          expect(firstGroup.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+            actor: 'Ian Holm',
+          });
+          const secondGroup = groups[1];
+          expect(secondGroup.name).toEqual('temporary');
+          expect(secondGroup.examples).toEqual({
+            age: 111,
+            family: 'underhill',
+            actor: 'Martin Freeman',
+          });
+          const defaultGroup = groups[2];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({
+            age: 111,
+            actor: 'Ian Holm',
+          });
+        });
+
+        it('merges non-required examples with default key into appropriate groups', () => {
+          familyParameter.examples = {
+            personal: {
+              value: 'baggins',
+            },
+            temporary: {
+              value: 'underhill',
+            },
+          };
+
+          actorParameter.required = false;
+
+          const operation = new OASOperation({
+            operationId: '123',
+            responses: {},
+            parameters: [ageParameter, familyParameter, actorParameter],
+          });
+          const groups = ExampleGroupFactory.buildFromOperation(operation);
+
+          expect(groups).toHaveLength(3);
+          const firstGroup = groups[0];
+          expect(firstGroup.name).toEqual('personal');
+          expect(firstGroup.examples).toEqual({
+            age: 111,
+            family: 'baggins',
+          });
+          const secondGroup = groups[1];
+          expect(secondGroup.name).toEqual('temporary');
+          expect(secondGroup.examples).toEqual({
+            age: 111,
+            family: 'underhill',
+            actor: 'Martin Freeman',
+          });
+          const defaultGroup = groups[2];
+          expect(defaultGroup.name).toEqual('default');
+          expect(defaultGroup.examples).toEqual({
+            age: 111,
+            actor: 'Ian Holm',
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
This PR is for [API-5840](https://vajira.max.gov/browse/API-5840). It ensures required and non-required parameters with the `example` field set or a `default` value in the `examples` field will all be merged together into the default parameter group.