### PR TITLE
Add example/examples check to parameter validator

### DIFF
--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -13,7 +13,7 @@ import OASSchema from '../utilities/oas-schema';
 import { OASSecurityType } from '../utilities/oas-security';
 import {
   ParameterSchemaValidator,
-  ParameterValidator,
+  ExampleGroupValidator,
   ResponseValidator,
 } from '../utilities/validators';
 import {
@@ -109,7 +109,7 @@ export default class Positive extends Command {
         failures = [...failures, ...parameterSchemaValidator.failures];
         warnings = [...warnings, ...parameterSchemaValidator.warnings];
 
-        const parameterValidator = new ParameterValidator(exampleGroup);
+        const parameterValidator = new ExampleGroupValidator(exampleGroup);
         parameterValidator.validate();
 
         failures = [...failures, ...parameterValidator.failures];

--- a/src/commands/types.d.ts
+++ b/src/commands/types.d.ts
@@ -1,20 +1,5 @@
-import { Response } from 'swagger-client';
 import ExampleGroup from '../utilities/example-group';
 import OASOperation from '../utilities/oas-operation';
-import { ValidationFailure } from '../validation-messages/failures';
-import { ValidationWarning } from '../validation-messages/warnings';
-
-export interface OperationResponse {
-  [operationExampleId: string]: Response;
-}
-
-export interface OperationFailures {
-  [operationExampleId: string]: ValidationFailure[];
-}
-
-export interface OperationWarnings {
-  [operationExampleId: string]: ValidationWarning[];
-}
 
 export interface OperationExample {
   id: string;

--- a/src/utilities/validators/example-group-validator.ts
+++ b/src/utilities/validators/example-group-validator.ts
@@ -5,7 +5,7 @@ import ExampleGroup from '../example-group';
 import OASOperation from '../oas-operation';
 import BaseValidator from './base-validator';
 
-class ParameterValidator extends BaseValidator {
+class ExampleGroupValidator extends BaseValidator {
   private exampleGroup: ExampleGroup;
 
   private operation: OASOperation;
@@ -57,7 +57,6 @@ class ParameterValidator extends BaseValidator {
     path: string[],
   ): void {
     if (parameterHasSchema(parameter)) {
-      // Parameter Object conatains field: schema; does not contain field: content
       this.validateObjectAgainstSchema(example, parameter.schema, [
         ...path,
         'example',
@@ -73,4 +72,4 @@ class ParameterValidator extends BaseValidator {
   }
 }
 
-export default ParameterValidator;
+export default ExampleGroupValidator;

--- a/src/utilities/validators/index.ts
+++ b/src/utilities/validators/index.ts
@@ -1,2 +1,3 @@
 export { default as ParameterValidator } from './parameter-validator';
+export { default as ParameterSchemaValidator } from './parameter-schema-validator';
 export { default as ResponseValidator } from './response-validator';

--- a/src/utilities/validators/index.ts
+++ b/src/utilities/validators/index.ts
@@ -1,3 +1,3 @@
-export { default as ParameterValidator } from './parameter-validator';
+export { default as ExampleGroupValidator } from './example-group-validator';
 export { default as ParameterSchemaValidator } from './parameter-schema-validator';
 export { default as ResponseValidator } from './response-validator';

--- a/src/utilities/validators/parameter-schema-validator.ts
+++ b/src/utilities/validators/parameter-schema-validator.ts
@@ -1,0 +1,69 @@
+import { ParameterObject } from 'swagger-client/schema';
+import {
+  parameterHasContent,
+  parameterHasSchema,
+} from '../../types/typeguards';
+import {
+  InvalidParameterContent,
+  InvalidParameterExample,
+  InvalidParameterObject,
+  MissingContentSchemaObject,
+} from '../../validation-messages/failures';
+import OASOperation from '../oas-operation';
+import BaseValidator from './base-validator';
+
+class ParameterSchemaValidator extends BaseValidator {
+  private operation: OASOperation;
+
+  constructor(operation: OASOperation) {
+    super();
+    this.operation = operation;
+  }
+
+  performValidation = (): void => {
+    this.operation.parameters.forEach((parameter) => {
+      this.checkParameterObject(parameter, ['parameters', parameter.name]);
+    });
+  };
+
+  private checkParameterObject(
+    parameter: ParameterObject,
+    path: string[],
+  ): void {
+    if (parameter.example && parameter.examples) {
+      this._failures = [...this._failures, new InvalidParameterExample(path)];
+    } else if (parameterHasContent(parameter)) {
+      // Parameter Object contains field: content
+      if (parameterHasSchema(parameter)) {
+        // ERROR: Parameter Object also contains field: schema.
+        this._failures = [...this._failures, new InvalidParameterObject(path)];
+      }
+
+      const [contentObjectKey, ...invalidKeys] = Object.keys(parameter.content);
+      if (invalidKeys.length > 0) {
+        // ERROR: Content Object contains more than one entry.
+        this._failures = [
+          ...this._failures,
+          new InvalidParameterContent([...path, 'content']),
+        ];
+      }
+
+      if (!parameter.content[contentObjectKey].schema) {
+        // ERROR: Content Object does not contain a Schema Object.
+        this._failures = [
+          ...this._failures,
+          new MissingContentSchemaObject([
+            ...path,
+            'content',
+            contentObjectKey,
+          ]),
+        ];
+      }
+    } else if (!parameterHasSchema(parameter)) {
+      // ERROR: Parameter Object must contain one of the following: schema, or content.
+      this._failures = [...this._failures, new InvalidParameterObject(path)];
+    }
+  }
+}
+
+export default ParameterSchemaValidator;

--- a/src/utilities/validators/parameter-validator.ts
+++ b/src/utilities/validators/parameter-validator.ts
@@ -5,6 +5,7 @@ import {
 } from '../../types/typeguards';
 import {
   InvalidParameterContent,
+  InvalidParameterExample,
   InvalidParameterObject,
   MissingContentSchemaObject,
   MissingRequiredParameters,
@@ -64,7 +65,12 @@ class ParameterValidator extends BaseValidator {
     example: Json,
     path: string[],
   ): void {
-    if (parameterHasSchema(parameter) && !parameterHasContent(parameter)) {
+    if (parameter.example && parameter.examples) {
+      this._failures = [...this._failures, new InvalidParameterExample(path)];
+    } else if (
+      parameterHasSchema(parameter) &&
+      !parameterHasContent(parameter)
+    ) {
       // Parameter Object conatains field: schema; does not contain field: content
       this.validateObjectAgainstSchema(example, parameter.schema, [
         ...path,

--- a/src/utilities/validators/parameter-validator.ts
+++ b/src/utilities/validators/parameter-validator.ts
@@ -1,15 +1,6 @@
 import { Json, ParameterObject } from 'swagger-client/schema';
-import {
-  parameterHasContent,
-  parameterHasSchema,
-} from '../../types/typeguards';
-import {
-  InvalidParameterContent,
-  InvalidParameterExample,
-  InvalidParameterObject,
-  MissingContentSchemaObject,
-  MissingRequiredParameters,
-} from '../../validation-messages/failures';
+import { parameterHasSchema } from '../../types/typeguards';
+import { MissingRequiredParameters } from '../../validation-messages/failures';
 import ExampleGroup from '../example-group';
 import OASOperation from '../oas-operation';
 import BaseValidator from './base-validator';
@@ -65,54 +56,19 @@ class ParameterValidator extends BaseValidator {
     example: Json,
     path: string[],
   ): void {
-    if (parameter.example && parameter.examples) {
-      this._failures = [...this._failures, new InvalidParameterExample(path)];
-    } else if (
-      parameterHasSchema(parameter) &&
-      !parameterHasContent(parameter)
-    ) {
+    if (parameterHasSchema(parameter)) {
       // Parameter Object conatains field: schema; does not contain field: content
       this.validateObjectAgainstSchema(example, parameter.schema, [
         ...path,
         'example',
       ]);
-    } else if (parameterHasContent(parameter)) {
-      // Parameter Object contains field: content
-      if (parameterHasSchema(parameter)) {
-        // ERROR: Parameter Object also contains field: schema.
-        this._failures = [...this._failures, new InvalidParameterObject(path)];
-      }
-
-      const [contentObjectKey, ...invalidKeys] = Object.keys(parameter.content);
-      if (invalidKeys.length > 0) {
-        // ERROR: Content Object contains more than one entry.
-        this._failures = [
-          ...this._failures,
-          new InvalidParameterContent([...path, 'content']),
-        ];
-      }
-
-      if (parameter.content[contentObjectKey].schema) {
-        // Content Object contains one entry and a Schema Object.
-        this.validateObjectAgainstSchema(
-          example,
-          parameter.content[contentObjectKey].schema,
-          [...path, 'example'],
-        );
-      } else {
-        // ERROR: Content Object does not contain a Schema Object.
-        this._failures = [
-          ...this._failures,
-          new MissingContentSchemaObject([
-            ...path,
-            'content',
-            contentObjectKey,
-          ]),
-        ];
-      }
     } else {
-      // ERROR: Parameter Object must contain one of the following: schema, or content.
-      this._failures = [...this._failures, new InvalidParameterObject(path)];
+      const contentObjectKey = Object.keys(parameter.content)[0];
+      this.validateObjectAgainstSchema(
+        example,
+        parameter.content[contentObjectKey].schema,
+        [...path, 'example'],
+      );
     }
   }
 }

--- a/src/validation-messages/failures/index.ts
+++ b/src/validation-messages/failures/index.ts
@@ -15,3 +15,4 @@ export { default as InvalidParameterObject } from './invalid-parameter-object';
 export { default as InvalidParameterContent } from './invalid-parameter-content';
 export { default as MissingContentSchemaObject } from './missing-content-schema-object';
 export { default as InvalidResponse } from './invalid-response';
+export { default as InvalidParameterExample } from './invalid-parameter-example';

--- a/src/validation-messages/failures/invalid-parameter-example.ts
+++ b/src/validation-messages/failures/invalid-parameter-example.ts
@@ -3,7 +3,7 @@ import ValidationFailure from './validation-failure';
 class InvalidParameterExample extends ValidationFailure {
   constructor(path: string[]) {
     super(
-      'Parameter object can have either example or examples set, but not both.',
+      "The 'example' field is mutually exclusive of the 'examples' field, provide one or the other or neither, but not both.",
       path,
     );
   }

--- a/src/validation-messages/failures/invalid-parameter-example.ts
+++ b/src/validation-messages/failures/invalid-parameter-example.ts
@@ -1,0 +1,12 @@
+import ValidationFailure from './validation-failure';
+
+class InvalidParameterExample extends ValidationFailure {
+  constructor(path: string[]) {
+    super(
+      'Parameter object must have either example or examples set, but not both.',
+      path,
+    );
+  }
+}
+
+export default InvalidParameterExample;

--- a/src/validation-messages/failures/invalid-parameter-example.ts
+++ b/src/validation-messages/failures/invalid-parameter-example.ts
@@ -3,7 +3,7 @@ import ValidationFailure from './validation-failure';
 class InvalidParameterExample extends ValidationFailure {
   constructor(path: string[]) {
     super(
-      'Parameter object must have either example or examples set, but not both.',
+      'Parameter object can have either example or examples set, but not both.',
       path,
     );
   }

--- a/test/fixtures/forms_oas.yaml
+++ b/test/fixtures/forms_oas.yaml
@@ -47,7 +47,8 @@ paths:
         in: query
         description: Query the form number as well as title
         required: false
-        type: string
+        schema:
+          type: string
       responses:
         '200':
           description: VAForms index response

--- a/test/utilities/validators/example-group-validator.test.ts
+++ b/test/utilities/validators/example-group-validator.test.ts
@@ -1,6 +1,6 @@
 import ExampleGroup from '../../../src/utilities/example-group';
 import OASOperation from '../../../src/utilities/oas-operation';
-import { ParameterValidator } from '../../../src/utilities/validators';
+import { ExampleGroupValidator } from '../../../src/utilities/validators';
 
 describe('ParameterValidator', () => {
   describe('validate', () => {
@@ -23,7 +23,7 @@ describe('ParameterValidator', () => {
           responses: {},
         });
         const exampleGroup = new ExampleGroup(operation, 'default', {});
-        const validator = new ParameterValidator(exampleGroup);
+        const validator = new ExampleGroupValidator(exampleGroup);
 
         validator.validate();
 
@@ -65,7 +65,7 @@ describe('ParameterValidator', () => {
           const exampleGroup = new ExampleGroup(operation, 'default', {
             family: 1,
           });
-          const validator = new ParameterValidator(exampleGroup);
+          const validator = new ExampleGroupValidator(exampleGroup);
           validator.validate();
 
           const failures = validator.failures;
@@ -97,7 +97,7 @@ describe('ParameterValidator', () => {
         responses: {},
       });
       const exampleGroup = new ExampleGroup(operation, 'default', { fit: 123 });
-      const validator = new ParameterValidator(exampleGroup);
+      const validator = new ExampleGroupValidator(exampleGroup);
 
       validator.validate();
 
@@ -126,7 +126,7 @@ describe('ParameterValidator', () => {
         responses: {},
       });
       const exampleGroup = new ExampleGroup(operation, 'default', {});
-      const validator = new ParameterValidator(exampleGroup);
+      const validator = new ExampleGroupValidator(exampleGroup);
 
       validator.validate();
 

--- a/test/utilities/validators/parameter-schema-validator.test.ts
+++ b/test/utilities/validators/parameter-schema-validator.test.ts
@@ -1,0 +1,264 @@
+import { ParameterObject } from 'swagger-client';
+import OASOperation from '../../../src/utilities/oas-operation';
+import { ParameterSchemaValidator } from '../../../src/utilities/validators';
+
+describe('ParameterSchemaValidator', () => {
+  describe('validate', () => {
+    it('it adds a validation failure if both content and schema exist on parameter', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          {
+            name: 'gryffindor',
+            in: 'query',
+            example: 'ginny weasly',
+            schema: {
+              type: 'string',
+              description: 'founded by Godric Gryffindor',
+            },
+            content: {
+              'document/howler': {
+                schema: {
+                  type: 'string',
+                },
+                example: 'ron weasly',
+              },
+            },
+          },
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'Parameter object must have either schema or content set, but not both. Path: parameters -> gryffindor',
+      );
+    });
+
+    it('registers a validation failure if content contains more than one entry', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          {
+            name: 'magical deliveries',
+            in: 'query',
+            example: 'the daily prophet',
+            content: {
+              'document/howler': {
+                schema: {
+                  type: 'string',
+                },
+                example: 'petunia dursley',
+              },
+              'owl/package': {
+                schema: {
+                  type: 'string',
+                },
+                example: 'nimbus 2000',
+              },
+            },
+          },
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'Parameter content object should only have one key. Path: parameters -> magical deliveries -> content',
+      );
+    });
+
+    it('adds a validation failure if content does not contain a schema object', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          ({
+            name: 'magical deliveries',
+            in: 'query',
+            example: 'the daily prophet',
+            content: {
+              'document/howler': {
+                hogwarts: {
+                  'magical deliveries': {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          } as unknown) as ParameterObject,
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
+      );
+    });
+
+    it('adds a validation failure if neither content nor schema exist on parameter', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          ({
+            name: 'horcrux',
+            in: 'query',
+            example: "tom riddle's diary",
+          } as unknown) as ParameterObject,
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'Parameter object must have either schema or content set, but not both. Path: parameters -> horcrux',
+      );
+    });
+
+    it('adds a validation failure if parameter has both example and examples', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          ({
+            name: 'horcrux',
+            in: 'query',
+            example: "tom riddle's diary",
+            examples: {
+              doesnot: 'matter',
+            },
+            schema: {
+              type: 'string',
+              description: 'founded by Godric Gryffindor',
+            },
+          } as unknown) as ParameterObject,
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        "The 'example' field is mutually exclusive of the 'examples' field, provide one or the other or neither, but not both. Path: parameters -> horcrux",
+      );
+    });
+
+    it('does not register a validation failure if content is shaped correctly', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          {
+            name: 'diagon alley shops',
+            in: 'query',
+            example: '2nd hand brooms',
+            content: {
+              'document/map': {
+                schema: {
+                  type: 'string',
+                },
+                example: 'flourish and blotts',
+              },
+            },
+          },
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(0);
+    });
+
+    it('does not register a validation failure if schema is shaped correctly', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          {
+            name: 'diagon alley shops',
+            in: 'query',
+            example: '2nd hand brooms',
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(0);
+    });
+
+    it('is idempotent', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          ({
+            name: 'magical deliveries',
+            in: 'query',
+            example: 'the daily prophet',
+            content: {
+              'document/howler': {
+                hogwarts: {
+                  'magical deliveries': {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          } as unknown) as ParameterObject,
+        ],
+        responses: {},
+      });
+
+      const validator = new ParameterSchemaValidator(operation);
+      validator.validate();
+
+      let failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
+      );
+
+      // call valdiate again to check for idempotency
+      validator.validate();
+
+      failures = validator.failures;
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
+      );
+    });
+  });
+});

--- a/test/utilities/validators/parameter-validator.test.ts
+++ b/test/utilities/validators/parameter-validator.test.ts
@@ -249,7 +249,7 @@ describe('ParameterValidator', () => {
 
       expect(failures).toHaveLength(1);
       expect(failures).toContainValidationFailure(
-        'Parameter object can have either example or examples set, but not both. Path: parameters -> horcrux',
+        "The 'example' field is mutually exclusive of the 'examples' field, provide one or the other or neither, but not both. Path: parameters -> horcrux",
       );
     });
 

--- a/test/utilities/validators/parameter-validator.test.ts
+++ b/test/utilities/validators/parameter-validator.test.ts
@@ -1,4 +1,3 @@
-import { ParameterObject } from 'swagger-client';
 import ExampleGroup from '../../../src/utilities/example-group';
 import OASOperation from '../../../src/utilities/oas-operation';
 import { ParameterValidator } from '../../../src/utilities/validators';
@@ -81,207 +80,32 @@ describe('ParameterValidator', () => {
       });
     });
 
-    it('it adds a validation failure if both content and schema exist on parameter', () => {
+    it('adds a validation failures if example does not match schema', () => {
       const operation = new OASOperation({
         operationId: 'hobbits or something',
         parameters: [
           {
-            name: 'gryffindor',
+            name: 'fit',
             in: 'query',
-            example: 'ginny weasly',
+            example: 'tight',
             schema: {
               type: 'string',
-              description: 'founded by Godric Gryffindor',
-            },
-            content: {
-              'document/howler': {
-                schema: {
-                  type: 'string',
-                },
-                example: 'ron weasly',
-              },
+              description: 'blah blah blah',
             },
           },
         ],
         responses: {},
       });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        gryffindor: 'luna lovegood',
-      });
+      const exampleGroup = new ExampleGroup(operation, 'default', { fit: 123 });
       const validator = new ParameterValidator(exampleGroup);
+
       validator.validate();
 
       const failures = validator.failures;
-
       expect(failures).toHaveLength(1);
       expect(failures).toContainValidationFailure(
-        'Parameter object must have either schema or content set, but not both. Path: parameters -> gryffindor',
+        'Actual type did not match schema. Schema type: string. Actual type: number. Path: parameters -> fit -> example',
       );
-    });
-
-    it('registers a validation failure if content contains more than one entry', () => {
-      const operation = new OASOperation({
-        operationId: 'hobbits or something',
-        parameters: [
-          {
-            name: 'magical deliveries',
-            in: 'query',
-            example: 'the daily prophet',
-            content: {
-              'document/howler': {
-                schema: {
-                  type: 'string',
-                },
-                example: 'petunia dursley',
-              },
-              'owl/package': {
-                schema: {
-                  type: 'string',
-                },
-                example: 'nimbus 2000',
-              },
-            },
-          },
-        ],
-        responses: {},
-      });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        'magical deliveries': 'firebolt',
-      });
-      const validator = new ParameterValidator(exampleGroup);
-      validator.validate();
-
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(1);
-      expect(failures).toContainValidationFailure(
-        'Parameter content object should only have one key. Path: parameters -> magical deliveries -> content',
-      );
-    });
-
-    it('adds a validation failure if content does not contain a schema object', () => {
-      const operation = new OASOperation({
-        operationId: 'hobbits or something',
-        parameters: [
-          ({
-            name: 'magical deliveries',
-            in: 'query',
-            example: 'the daily prophet',
-            content: {
-              'document/howler': {
-                hogwarts: {
-                  'magical deliveries': {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-          } as unknown) as ParameterObject,
-        ],
-        responses: {},
-      });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        'magical deliveries': "weasley's wizard wheezes",
-      });
-      const validator = new ParameterValidator(exampleGroup);
-      validator.validate();
-
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(1);
-      expect(failures).toContainValidationFailure(
-        'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
-      );
-    });
-
-    it('adds a validation failure if neither content nor schema exist on parameter', () => {
-      const operation = new OASOperation({
-        operationId: 'hobbits or something',
-        parameters: [
-          ({
-            name: 'horcrux',
-            in: 'query',
-            example: "tom riddle's diary",
-          } as unknown) as ParameterObject,
-        ],
-        responses: {},
-      });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        horcrux: 'nagini',
-      });
-      const validator = new ParameterValidator(exampleGroup);
-      validator.validate();
-
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(1);
-      expect(failures).toContainValidationFailure(
-        'Parameter object must have either schema or content set, but not both. Path: parameters -> horcrux',
-      );
-    });
-
-    it('adds a validation failure if parameter has both example and examples', () => {
-      const operation = new OASOperation({
-        operationId: 'hobbits or something',
-        parameters: [
-          ({
-            name: 'horcrux',
-            in: 'query',
-            example: "tom riddle's diary",
-            examples: {
-              doesnot: 'matter',
-            },
-            schema: {
-              type: 'string',
-              description: 'founded by Godric Gryffindor',
-            },
-          } as unknown) as ParameterObject,
-        ],
-        responses: {},
-      });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        horcrux: 'nagini',
-      });
-      const validator = new ParameterValidator(exampleGroup);
-      validator.validate();
-
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(1);
-      expect(failures).toContainValidationFailure(
-        "The 'example' field is mutually exclusive of the 'examples' field, provide one or the other or neither, but not both. Path: parameters -> horcrux",
-      );
-    });
-
-    it('does not register a validation failure if content is shaped correctly', () => {
-      const operation = new OASOperation({
-        operationId: 'hobbits or something',
-        parameters: [
-          {
-            name: 'diagon alley shops',
-            in: 'query',
-            example: '2nd hand brooms',
-            content: {
-              'document/map': {
-                schema: {
-                  type: 'string',
-                },
-                example: 'flourish and blotts',
-              },
-            },
-          },
-        ],
-        responses: {},
-      });
-      const exampleGroup = new ExampleGroup(operation, 'default', {
-        'diagon alley shops': 'ollivanders',
-      });
-      const validator = new ParameterValidator(exampleGroup);
-      validator.validate();
-
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(0);
     });
 
     it('is idempotent', () => {

--- a/test/utilities/validators/parameter-validator.test.ts
+++ b/test/utilities/validators/parameter-validator.test.ts
@@ -249,7 +249,7 @@ describe('ParameterValidator', () => {
 
       expect(failures).toHaveLength(1);
       expect(failures).toContainValidationFailure(
-        'Parameter object must have either example or examples set, but not both. Path: parameters -> horcrux',
+        'Parameter object can have either example or examples set, but not both. Path: parameters -> horcrux',
       );
     });
 

--- a/test/utilities/validators/parameter-validator.test.ts
+++ b/test/utilities/validators/parameter-validator.test.ts
@@ -220,6 +220,39 @@ describe('ParameterValidator', () => {
       );
     });
 
+    it('adds a validation failure if parameter has both example and examples', () => {
+      const operation = new OASOperation({
+        operationId: 'hobbits or something',
+        parameters: [
+          ({
+            name: 'horcrux',
+            in: 'query',
+            example: "tom riddle's diary",
+            examples: {
+              doesnot: 'matter',
+            },
+            schema: {
+              type: 'string',
+              description: 'founded by Godric Gryffindor',
+            },
+          } as unknown) as ParameterObject,
+        ],
+        responses: {},
+      });
+      const exampleGroup = new ExampleGroup(operation, 'default', {
+        horcrux: 'nagini',
+      });
+      const validator = new ParameterValidator(exampleGroup);
+      validator.validate();
+
+      const failures = validator.failures;
+
+      expect(failures).toHaveLength(1);
+      expect(failures).toContainValidationFailure(
+        'Parameter object must have either example or examples set, but not both. Path: parameters -> horcrux',
+      );
+    });
+
     it('does not register a validation failure if content is shaped correctly', () => {
       const operation = new OASOperation({
         operationId: 'hobbits or something',


### PR DESCRIPTION
This adds a check to the parameter validator to make sure that the parameter doesn't have both an example and examples key set.