### PR TITLE
API-7947 LOAST does not break when there are no parameters

### DIFF
--- a/src/utilities/example-group/example-group.factory.ts
+++ b/src/utilities/example-group/example-group.factory.ts
@@ -17,9 +17,8 @@ class ExampleGroupFactory {
     const groupNames = this.getGroupNames(parameters);
 
     const requiredExamples = this.getRequiredExamples(parameters);
-    const nonRequiredExamplesWithExampleField = this.nonRequiredExamplesWithExampleField(
-      parameters,
-    );
+    const nonRequiredExamplesWithExampleField =
+      this.nonRequiredExamplesWithExampleField(parameters);
 
     let exampleGroups: ExampleGroup[] = [];
 
@@ -62,9 +61,7 @@ class ExampleGroupFactory {
     return exampleGroups;
   }
 
-  private static nonRequiredExamplesWithExampleField(
-    parameters,
-  ): {
+  private static nonRequiredExamplesWithExampleField(parameters): {
     [name: string]: Json;
   } {
     return parameters.reduce((examples, parameter) => {

--- a/src/utilities/example-group/example-group.factory.ts
+++ b/src/utilities/example-group/example-group.factory.ts
@@ -17,8 +17,9 @@ class ExampleGroupFactory {
     const groupNames = this.getGroupNames(parameters);
 
     const requiredExamples = this.getRequiredExamples(parameters);
-    const nonRequiredExamplesWithExampleField = 
-      this.nonRequiredExamplesWithExampleField(parameters);
+    const nonRequiredExamplesWithExampleField = this.nonRequiredExamplesWithExampleField(
+      parameters,
+    );
 
     let exampleGroups: ExampleGroup[] = [];
 
@@ -62,7 +63,7 @@ class ExampleGroupFactory {
   }
 
   private static nonRequiredExamplesWithExampleField(
-  parameters,
+    parameters,
   ): {
     [name: string]: Json;
   } {

--- a/src/utilities/example-group/example-group.factory.ts
+++ b/src/utilities/example-group/example-group.factory.ts
@@ -11,55 +11,55 @@ import ExampleGroup from './example-group';
 class ExampleGroupFactory {
   static buildFromOperation(operation: OASOperation): ExampleGroup[] | [] {
     const parameters = operation.parameters;
-    if (parameters) {
-      const groupNames = this.getGroupNames(parameters);
 
-      const requiredExamples = this.getRequiredExamples(parameters);
-      const nonRequiredExamplesWithExampleField = this.nonRequiredExamplesWithExampleField(
-        parameters,
-      );
+    if (!parameters) return [];
 
-      let exampleGroups: ExampleGroup[] = [];
+    const groupNames = this.getGroupNames(parameters);
 
-      if (groupNames.length > 0) {
-        exampleGroups = groupNames.reduce<ExampleGroup[]>(
-          (exampleGroups, groupName) => {
-            if (groupName === DEFAULT_PARAMETER_GROUP) {
-              return [
-                ...exampleGroups,
-                this.findExamplesForGroup(operation, groupName, parameters, {
-                  ...requiredExamples,
-                  ...nonRequiredExamplesWithExampleField,
-                }),
-              ];
-            }
+    const requiredExamples = this.getRequiredExamples(parameters);
+    const nonRequiredExamplesWithExampleField = this.nonRequiredExamplesWithExampleField(
+      parameters,
+    );
 
+    let exampleGroups: ExampleGroup[] = [];
+
+    if (groupNames.length > 0) {
+      exampleGroups = groupNames.reduce<ExampleGroup[]>(
+        (exampleGroups, groupName) => {
+          if (groupName === DEFAULT_PARAMETER_GROUP) {
             return [
               ...exampleGroups,
-              this.findExamplesForGroup(
-                operation,
-                groupName,
-                parameters,
-                requiredExamples,
-              ),
+              this.findExamplesForGroup(operation, groupName, parameters, {
+                ...requiredExamples,
+                ...nonRequiredExamplesWithExampleField,
+              }),
             ];
-          },
-          [],
-        );
-      }
+          }
 
-      if (!groupNames.includes(DEFAULT_PARAMETER_GROUP)) {
-        const defaultGroup = new ExampleGroup(
-          operation,
-          DEFAULT_PARAMETER_GROUP,
-          { ...requiredExamples, ...nonRequiredExamplesWithExampleField },
-        );
-        exampleGroups.push(defaultGroup);
-      }
-
-      return exampleGroups;
+          return [
+            ...exampleGroups,
+            this.findExamplesForGroup(
+              operation,
+              groupName,
+              parameters,
+              requiredExamples,
+            ),
+          ];
+        },
+        [],
+      );
     }
-    return [];
+
+    if (!groupNames.includes(DEFAULT_PARAMETER_GROUP)) {
+      const defaultGroup = new ExampleGroup(
+        operation,
+        DEFAULT_PARAMETER_GROUP,
+        { ...requiredExamples, ...nonRequiredExamplesWithExampleField },
+      );
+      exampleGroups.push(defaultGroup);
+    }
+
+    return exampleGroups;
   }
 
   private static nonRequiredExamplesWithExampleField(

--- a/src/utilities/example-group/example-group.factory.ts
+++ b/src/utilities/example-group/example-group.factory.ts
@@ -17,9 +17,8 @@ class ExampleGroupFactory {
     const groupNames = this.getGroupNames(parameters);
 
     const requiredExamples = this.getRequiredExamples(parameters);
-    const nonRequiredExamplesWithExampleField = this.nonRequiredExamplesWithExampleField(
-      parameters,
-    );
+    const nonRequiredExamplesWithExampleField = 
+      this.nonRequiredExamplesWithExampleField(parameters);
 
     let exampleGroups: ExampleGroup[] = [];
 
@@ -63,7 +62,7 @@ class ExampleGroupFactory {
   }
 
   private static nonRequiredExamplesWithExampleField(
-    parameters,
+  parameters,
   ): {
     [name: string]: Json;
   } {

--- a/src/utilities/oas-operation/oas-operation.factory.ts
+++ b/src/utilities/oas-operation/oas-operation.factory.ts
@@ -36,7 +36,8 @@ class OASOperationFactory {
     });
 
     return operationObjects.map((operation) => {
-      operation.parameters = [...params, ...operation.parameters];
+      if (operation.parameters)
+        operation.parameters = [...params, ...operation.parameters];
       return new OASOperation(operation, securities);
     });
   }


### PR DESCRIPTION
Story: [API-7947](https://vajira.max.gov/browse/API-7947)

Bug fix for LOAST breaking if Operation Objects contain no Parameter Objects.