### PR TITLE
API-4326 semantic release fix

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && git cz --hook || true
+exec < /dev/tty && npx cz --hook || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please consider these guidelines when filing a pull request:
 *  Commits follow the [Angular commit convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
     *  Commits messages are enforced using husky hooks and [commitlint](https://github.com/conventional-changelog/commitlint)
     *  [Commitizen](https://github.com/commitizen/cz-cli) can be used to create commits following the correct format. This is integrated in a commit message hook, so can be accessed by simply typing `git commit`
-        * You will need to install the CLI first using `npm install -g commitizen`
+        * You will need to install husky on the repo first by running `./node_modules/.bin/husky install`
 *  Prettier is used to enforce code style
 *  eslint is used to enforce code quality
 *  Features and bug fixes should be covered by test cases


### PR DESCRIPTION
[API-4326](https://vajira.max.gov/browse/API-4326)

Switch to using `npx` so that we don't have to globally install commitizen
Add command to install husky so that hooks work