### PR TITLE
API-9258 example array handling

### DIFF
--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -110,12 +110,11 @@ abstract class BaseValidator {
     }
     if (expected.type === 'array') {
       // check that the actual object is an array
-      if(expected.items?.type === "string") {
+      isUnexpectedType = !Array.isArray(actual);
+
+      if(!Array.isArray(actual) && expected.items?.type === "string") {
          // Arrays can be represented as a string (single value)
          isUnexpectedType = !isString(actual);
-      }
-      else {
-        isUnexpectedType = !Array.isArray(actual);
       }
 
     } else if (expected.type === 'integer') {

--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -1,4 +1,4 @@
-import { isEqual, uniqWith, isString } from 'lodash';
+import { isEqual, uniqWith } from 'lodash';
 import { Json, SchemaObject } from 'swagger-client/schema';
 import {
   DuplicateEnum,
@@ -111,11 +111,6 @@ abstract class BaseValidator {
     if (expected.type === 'array') {
       // check that the actual object is an array
       isUnexpectedType = !Array.isArray(actual);
-
-      if (!Array.isArray(actual) && expected.items?.type === 'string') {
-        // Arrays can be represented as a string (single value)
-        isUnexpectedType = !isString(actual);
-      }
     } else if (expected.type === 'integer') {
       // check that the actual value is an integer
       isUnexpectedType = !Number.isInteger(actual);

--- a/src/utilities/validators/base-validator.ts
+++ b/src/utilities/validators/base-validator.ts
@@ -112,11 +112,10 @@ abstract class BaseValidator {
       // check that the actual object is an array
       isUnexpectedType = !Array.isArray(actual);
 
-      if(!Array.isArray(actual) && expected.items?.type === "string") {
-         // Arrays can be represented as a string (single value)
-         isUnexpectedType = !isString(actual);
+      if (!Array.isArray(actual) && expected.items?.type === 'string') {
+        // Arrays can be represented as a string (single value)
+        isUnexpectedType = !isString(actual);
       }
-
     } else if (expected.type === 'integer') {
       // check that the actual value is an integer
       isUnexpectedType = !Number.isInteger(actual);
@@ -125,7 +124,7 @@ abstract class BaseValidator {
       isUnexpectedType = true;
     }
 
-    if(isUnexpectedType) {
+    if (isUnexpectedType) {
       this._failures = [
         ...this._failures,
         new TypeMismatch([...path], expected.type, actualType),

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -443,31 +443,6 @@ describe('BaseValidator', () => {
         });
       });
 
-      const schemaSingleValueArray: SchemaObject = {
-        type: 'array',
-        items: {
-          type: 'string',
-          description: 'a string',
-        },
-        description: 'an array of a single string',
-      };
-
-      describe('object is single value string array', () => {
-        it('Insure single value string array passes validation', () => {
-          const object = 'this is a string';
-
-          const startFailureCount = validator.failures.length;
-
-          validator.validateObjectAgainstSchema(
-            object,
-            schemaSingleValueArray,
-            ['body', 'string'],
-          );
-
-          expect(validator.failures.length).toEqual(startFailureCount);
-        });
-      });
-
       describe('object is an array', () => {
         describe('items property is not defined in schema', () => {
           let originalItems;

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -443,6 +443,30 @@ describe('BaseValidator', () => {
         });
       });
 
+      const schemaSingleValueArray: SchemaObject = {
+        type: 'array',
+        items: {
+          type: 'string',
+          description: 'a string',
+        },
+        description: 'an array of a single string',
+      };
+  
+      describe('object is single value string array', () => {
+        it('Insure single value string array passes validation', () => {
+          const object = 'this is a string';
+
+          let startFailureCount = validator.failures.length;
+
+          validator.validateObjectAgainstSchema(object, schemaSingleValueArray, [
+            'body',
+            'string',
+          ]);
+
+          expect(validator.failures.length).toEqual(startFailureCount);
+        });
+      });
+
       describe('object is an array', () => {
         describe('items property is not defined in schema', () => {
           let originalItems;

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -451,17 +451,18 @@ describe('BaseValidator', () => {
         },
         description: 'an array of a single string',
       };
-  
+
       describe('object is single value string array', () => {
         it('Insure single value string array passes validation', () => {
           const object = 'this is a string';
 
-          let startFailureCount = validator.failures.length;
+          const startFailureCount = validator.failures.length;
 
-          validator.validateObjectAgainstSchema(object, schemaSingleValueArray, [
-            'body',
-            'string',
-          ]);
+          validator.validateObjectAgainstSchema(
+            object,
+            schemaSingleValueArray,
+            ['body', 'string'],
+          );
 
           expect(validator.failures.length).toEqual(startFailureCount);
         });


### PR DESCRIPTION
- Added fix for single value string array for examples.
- Included one new validation test case
- Changes included additional cleanup of BaseValidator.checkExpectedType() method