### PR TITLE
Remove duplicate validation messages from LOAST output

### DIFF
--- a/src/utilities/validators/example-group-validator.ts
+++ b/src/utilities/validators/example-group-validator.ts
@@ -34,10 +34,7 @@ class ExampleGroupValidator extends BaseValidator {
     );
 
     if (missingRequiredParameters.length > 0) {
-      this._failures = [
-        ...this._failures,
-        new MissingRequiredParameters(missingRequiredParameters),
-      ];
+      this.addFailure(new MissingRequiredParameters(missingRequiredParameters));
     }
   }
 

--- a/src/utilities/validators/parameter-schema-validator.ts
+++ b/src/utilities/validators/parameter-schema-validator.ts
@@ -31,37 +31,33 @@ class ParameterSchemaValidator extends BaseValidator {
     path: string[],
   ): void {
     if (parameter.example && parameter.examples) {
-      this._failures = [...this._failures, new InvalidParameterExample(path)];
+      this.addFailure(new InvalidParameterExample(path));
     } else if (parameterHasContent(parameter)) {
       // Parameter Object contains field: content
       if (parameterHasSchema(parameter)) {
         // ERROR: Parameter Object also contains field: schema.
-        this._failures = [...this._failures, new InvalidParameterObject(path)];
+        this.addFailure(new InvalidParameterObject(path));
       }
 
       const [contentObjectKey, ...invalidKeys] = Object.keys(parameter.content);
       if (invalidKeys.length > 0) {
         // ERROR: Content Object contains more than one entry.
-        this._failures = [
-          ...this._failures,
-          new InvalidParameterContent([...path, 'content']),
-        ];
+        this.addFailure(new InvalidParameterContent([...path, 'content']));
       }
 
       if (!parameter.content[contentObjectKey].schema) {
         // ERROR: Content Object does not contain a Schema Object.
-        this._failures = [
-          ...this._failures,
+        this.addFailure(
           new MissingContentSchemaObject([
             ...path,
             'content',
             contentObjectKey,
           ]),
-        ];
+        );
       }
     } else if (!parameterHasSchema(parameter)) {
       // ERROR: Parameter Object must contain one of the following: schema, or content.
-      this._failures = [...this._failures, new InvalidParameterObject(path)];
+      this.addFailure(new InvalidParameterObject(path));
     }
   }
 }

--- a/src/utilities/validators/response-validator.ts
+++ b/src/utilities/validators/response-validator.ts
@@ -28,10 +28,7 @@ class ResponseValidator extends BaseValidator {
       const contentTypeSchema = responseSchema.content[contentType];
 
       if (!contentTypeSchema) {
-        this._failures = [
-          ...this._failures,
-          new ContentTypeMismatch(contentType),
-        ];
+        this.addFailure(new ContentTypeMismatch(contentType));
         return;
       }
 
@@ -41,10 +38,7 @@ class ResponseValidator extends BaseValidator {
         ['body'],
       );
     } else {
-      this._failures = [
-        ...this._failures,
-        new StatusCodeMismatch(this.response.status),
-      ];
+      this.addFailure(new StatusCodeMismatch(this.response.status));
     }
   };
 }

--- a/src/validation-messages/validation-message.ts
+++ b/src/validation-messages/validation-message.ts
@@ -1,11 +1,31 @@
+import crypto from 'crypto';
+
 abstract class ValidationMessage {
   protected message: string;
 
-  private path: string[];
+  private _path: string[];
+
+  private _hash: string;
+
+  private _count: number;
 
   constructor(message, path) {
-    this.path = path;
-    this.message = `${message}${this.generatePath(this.path)}`;
+    this._path = path;
+    this.message = `${message}${this.generatePath(this._path)}`;
+    this._hash = this.generateHash();
+    this._count = 1;
+  }
+
+  public get hash(): string {
+    return this._hash;
+  }
+
+  public get count(): number {
+    return this._count;
+  }
+
+  public incrementCount(): void {
+    this._count++;
   }
 
   private generatePath(path: string[]): string {
@@ -14,6 +34,13 @@ abstract class ValidationMessage {
     }
 
     return '';
+  }
+
+  private generateHash(): string {
+    const hash = crypto.createHash('sha1');
+
+    hash.update(this.message);
+    return hash.digest('hex');
   }
 
   toString = (): string => {

--- a/src/validation-messages/warnings/missing-properties.ts
+++ b/src/validation-messages/warnings/missing-properties.ts
@@ -3,7 +3,7 @@ import ValidationWarning from './validation-warning';
 class MissingProperties extends ValidationWarning {
   constructor(missingParameters, path) {
     super(
-      `This object is missing non-required parameters that were unable to be validated, including ${missingParameters.join(
+      `This object is missing non-required properties that were unable to be validated, including ${missingParameters.join(
         ', ',
       )}.`,
       path,

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -136,25 +136,6 @@ describe('Positive', () => {
     });
   });
 
-  describe('API key is not set', () => {
-    beforeEach(() => {
-      process.env.API_KEY = '';
-    });
-
-    it("does not request an apiKey when apiKey scheme doesn't exist", async () => {
-      mockGetSecuritySchemes.mockReset();
-      mockGetSecuritySchemes.mockResolvedValue([
-        {
-          securityType: 'http',
-          description: 'one does simply walk into VA APIs',
-          name: 'boromir-security',
-        },
-      ]);
-      await Positive.run(['http://isengard.com']);
-      expect(mockPrompt).not.toHaveBeenCalled();
-    });
-  });
-
   describe('The path is to a file', () => {
     beforeEach(() => {
       process.env.API_KEY = 'testApiKey';
@@ -213,225 +194,49 @@ describe('Positive', () => {
       expect(result).toEqual(['getHobbit - default: Succeeded\n']);
     });
 
-    it('outputs a failure for an operation if parameter validation fails', async () => {
-      mockGetOperations.mockResolvedValue([
-        new OASOperation({
-          operationId: 'walkIntoMordor',
-          parameters: [
-            {
-              name: 'guide',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              required: true,
-              example: 42,
-            },
-          ],
-          responses: defaultResponses,
-        }),
-      ]);
-
-      await expect(async () => {
-        await Positive.run(['http://urldoesnotmatter.com']);
-      }).rejects.toThrow('1 operation failed');
-
-      expect(result).toEqual([
-        'walkIntoMordor - default: Failed\n',
-        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: parameters -> guide -> example\n',
-      ]);
-    });
-
-    describe('operation has parameter groups', () => {
-      it('does not execute a request for a parameter group that fails parameter validation', async () => {
-        const operation1 = new OASOperation({
-          operationId: 'walkIntoMordor',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'door',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              examples: {
-                door: {
-                  value: 2,
-                },
-              },
-            },
-            {
-              name: 'guide',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              examples: {
-                guided: {
-                  value: 'gollum',
-                },
-              },
-            },
-          ],
-        });
-        const operation2 = new OASOperation({
-          operationId: 'getHobbit',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'name',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              example: 'Frodo',
-            },
-          ],
-        });
-        const operation3 = new OASOperation({
-          operationId: 'getTomBombadil',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'times',
-              in: 'query',
-              example: 2,
-              schema: {
-                type: 'number',
-              },
-            },
-          ],
-        });
-        mockGetOperations.mockResolvedValue([
-          operation1,
-          operation2,
-          operation3,
-        ]);
-
-        const security = {};
-
+    describe('Unsupported file type', () => {
+      it('throws an error', async () => {
         await expect(async () => {
-          await Positive.run(['http://urldoesnotmatter.com']);
-        }).rejects.toThrow('1 operation failed');
-
-        expect(mockExecute).not.toHaveBeenCalledWith(
-          operation1,
-          operation1.exampleGroups[0],
-          security,
-        );
-
-        expect(mockExecute).toHaveBeenCalledWith(
-          operation1,
-          operation1.exampleGroups[1],
-          security,
-        );
-
-        expect(mockExecute).toHaveBeenCalledWith(
-          operation2,
-          operation2.exampleGroups[0],
-          security,
-        );
-
-        expect(mockExecute).toHaveBeenCalledWith(
-          operation3,
-          operation3.exampleGroups[0],
-          security,
+          await Positive.run(['./test/fixtures/file.xml']);
+        }).rejects.toThrow(
+          'File is of a type not supported by OAS (.json, .yml, .yaml)',
         );
       });
-
-      it('validates the responses for each parameter group', async () => {
-        const operation1 = new OASOperation({
-          operationId: 'walkIntoMordor',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'door',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              examples: {
-                door: {
-                  value: 'front',
-                },
-              },
-            },
-            {
-              name: 'guide',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              examples: {
-                guided: {
-                  value: 'gollum',
-                },
-              },
-            },
-          ],
-        });
-        const operation2 = new OASOperation({
-          operationId: 'getHobbit',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'name',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              example: 'Frodo',
-            },
-          ],
-        });
-        const operation3 = new OASOperation({
-          operationId: 'getTomBombadil',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'times',
-              in: 'query',
-              example: 2,
-              schema: {
-                type: 'number',
-              },
-            },
-          ],
-        });
-        mockGetOperations.mockResolvedValue([
-          operation1,
-          operation2,
-          operation3,
-        ]);
-
-        mockExecute.mockResolvedValueOnce({
-          url: 'https://www.lotr.com/walkIntoMorder',
-          status: 200,
-          ok: true,
-          body: {
-            data: [42],
-          },
-          headers: {
-            'content-type': 'application/json',
-          },
-        });
-
-        await expect(async () => {
-          await Positive.run(['http://urldoesnotmatter.com']);
-        }).rejects.toThrow('1 operation failed');
-
-        expect(result).toEqual([
-          'walkIntoMordor - door: Failed\n',
-          '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data\n',
-          'walkIntoMordor - guided: Succeeded\n',
-          'walkIntoMordor - default: Succeeded\n',
-          'getHobbit - default: Succeeded\n',
-          'getTomBombadil - default: Succeeded\n',
-        ]);
-      });
     });
+  });
 
-    it('outputs the failures and throws an error when more than one of the operations fails validation', async () => {
+  describe('operation has parameter groups', () => {
+    it('does not execute a request for a parameter group that fails parameter validation', async () => {
+      const operation1 = new OASOperation({
+        operationId: 'walkIntoMordor',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'door',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            examples: {
+              door: {
+                value: 2,
+              },
+            },
+          },
+          {
+            name: 'guide',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            examples: {
+              guided: {
+                value: 'gollum',
+              },
+            },
+          },
+        ],
+      });
       const operation2 = new OASOperation({
         operationId: 'getHobbit',
         responses: defaultResponses,
@@ -460,9 +265,101 @@ describe('Positive', () => {
           },
         ],
       });
-      mockGetOperations.mockResolvedValue([operation2, operation3]);
+      mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
 
-      mockExecute.mockResolvedValue({
+      const security = {};
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('1 operation failed');
+
+      expect(mockExecute).not.toHaveBeenCalledWith(
+        operation1,
+        operation1.exampleGroups[0],
+        security,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        operation1,
+        operation1.exampleGroups[1],
+        security,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        operation2,
+        operation2.exampleGroups[0],
+        security,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        operation3,
+        operation3.exampleGroups[0],
+        security,
+      );
+    });
+
+    it('validates the responses for each parameter group', async () => {
+      const operation1 = new OASOperation({
+        operationId: 'walkIntoMordor',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'door',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            examples: {
+              door: {
+                value: 'front',
+              },
+            },
+          },
+          {
+            name: 'guide',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            examples: {
+              guided: {
+                value: 'gollum',
+              },
+            },
+          },
+        ],
+      });
+      const operation2 = new OASOperation({
+        operationId: 'getHobbit',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'name',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            example: 'Frodo',
+          },
+        ],
+      });
+      const operation3 = new OASOperation({
+        operationId: 'getTomBombadil',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'times',
+            in: 'query',
+            example: 2,
+            schema: {
+              type: 'number',
+            },
+          },
+        ],
+      });
+      mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
+
+      mockExecute.mockResolvedValueOnce({
         url: 'https://www.lotr.com/walkIntoMorder',
         status: 200,
         ok: true,
@@ -476,207 +373,16 @@ describe('Positive', () => {
 
       await expect(async () => {
         await Positive.run(['http://urldoesnotmatter.com']);
-      }).rejects.toThrow('2 operations failed');
-
-      expect(result).toEqual([
-        'getHobbit - default: Failed\n',
-        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data\n',
-        'getTomBombadil - default: Failed\n',
-        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data\n',
-      ]);
-    });
-
-    it('outputs the failure and throws an error when one of the responses returns a non-ok status', async () => {
-      const operation2 = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      const operation3 = new OASOperation({
-        operationId: 'getTomBombadil',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'times',
-            in: 'query',
-            example: 2,
-            schema: {
-              type: 'number',
-            },
-          },
-        ],
-      });
-      mockGetOperations.mockResolvedValue([operation2, operation3]);
-
-      mockExecute.mockResolvedValueOnce({
-        url: 'https://www.lotr.com/walkIntoMorder',
-        status: 404,
-        ok: false,
-        body: {},
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
-
-      await expect(async () => {
-        await Positive.run(['http://urldoesnotmatter.com']);
       }).rejects.toThrow('1 operation failed');
 
       expect(result).toEqual([
-        'getHobbit - default: Failed\n',
-        '  - Response status code was a non 2XX value\n',
+        'walkIntoMordor - door: Failed\n',
+        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data. Found 1 time\n',
+        'walkIntoMordor - guided: Succeeded\n',
+        'walkIntoMordor - default: Succeeded\n',
+        'getHobbit - default: Succeeded\n',
         'getTomBombadil - default: Succeeded\n',
       ]);
-    });
-
-    it('outputs all the failures when one of the operations returns more than one validation failure', async () => {
-      const operation = new OASOperation({
-        operationId: 'getHobbit',
-        responses: {
-          '200': {
-            description: '',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    data: {
-                      type: 'object',
-                      properties: {
-                        one: {
-                          type: 'number',
-                        },
-                        two: {
-                          type: 'string',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      mockGetOperations.mockResolvedValue([operation]);
-
-      mockExecute.mockResolvedValueOnce({
-        url: 'https://www.lotr.com/walkIntoMorder',
-        status: 200,
-        ok: true,
-        body: {
-          data: {
-            one: 'number',
-            two: 42,
-          },
-        },
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
-
-      await expect(async () => {
-        await Positive.run(['http://urldoesnotmatter.com']);
-      }).rejects.toThrow('1 operation failed');
-
-      expect(result).toEqual([
-        'getHobbit - default: Failed\n',
-        '  - Actual type did not match schema. Schema type: number. Actual type: string. Path: body -> data -> one\n',
-        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data -> two\n',
-      ]);
-    });
-
-    it('outputs any present warnings', async () => {
-      const operation = new OASOperation({
-        operationId: 'getHobbit',
-        responses: {
-          '200': {
-            description: '',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    data: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        properties: {
-                          one: {
-                            type: 'number',
-                          },
-                          two: {
-                            type: 'string',
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      mockGetOperations.mockResolvedValue([operation]);
-
-      mockExecute.mockResolvedValueOnce({
-        url: 'https://www.lotr.com/walkIntoMorder',
-        status: 200,
-        ok: true,
-        body: {
-          data: [],
-        },
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
-
-      await Positive.run(['http://urldoesnotmatter.com']);
-
-      expect(result).toEqual([
-        'getHobbit - default: Succeeded\n',
-        '  - Warning: This array was found to be empty and therefore could not be validated. Path: body -> data\n',
-      ]);
-    });
-  });
-
-  describe('Unsupported file type', () => {
-    it('throws an error', async () => {
-      await expect(async () => {
-        await Positive.run(['./test/fixtures/file.xml']);
-      }).rejects.toThrow(
-        'File is of a type not supported by OAS (.json, .yml, .yaml)',
-      );
     });
   });
 
@@ -684,6 +390,25 @@ describe('Positive', () => {
     beforeEach(() => {
       mockPrompt.mockReset();
       mockGetSecuritySchemes.mockReset();
+    });
+
+    describe('API key is not set', () => {
+      beforeEach(() => {
+        process.env.API_KEY = '';
+      });
+
+      it("does not request an apiKey when apiKey scheme doesn't exist", async () => {
+        mockGetSecuritySchemes.mockReset();
+        mockGetSecuritySchemes.mockResolvedValue([
+          {
+            securityType: 'http',
+            description: 'one does simply walk into VA APIs',
+            name: 'boromir-security',
+          },
+        ]);
+        await Positive.run(['http://isengard.com']);
+        expect(mockPrompt).not.toHaveBeenCalled();
+      });
     });
 
     it('requests an apiKey when apiKey scheme exists', async () => {
@@ -766,6 +491,274 @@ describe('Positive', () => {
   See more at: https://swagger.io/specification/#security-requirement-object`);
 
       expect(mockPrompt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('output', () => {
+    const operation = new OASOperation({
+      operationId: 'getHobbits',
+      responses: {
+        '200': {
+          description: '',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        one: {
+                          type: 'number',
+                        },
+                        two: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      parameters: [
+        {
+          name: 'name',
+          in: 'query',
+          schema: {
+            type: 'string',
+          },
+          example: 'Frodo',
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      mockGetOperations.mockResolvedValue([operation]);
+    });
+
+    it('outputs a failure for an operation if parameter validation fails', async () => {
+      mockGetOperations.mockResolvedValue([
+        new OASOperation({
+          operationId: 'walkIntoMordor',
+          parameters: [
+            {
+              name: 'guide',
+              in: 'query',
+              schema: {
+                type: 'string',
+              },
+              required: true,
+              example: 42,
+            },
+          ],
+          responses: defaultResponses,
+        }),
+      ]);
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('1 operation failed');
+
+      expect(result).toEqual([
+        'walkIntoMordor - default: Failed\n',
+        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: parameters -> guide -> example. Found 1 time\n',
+      ]);
+    });
+
+    it('outputs the failures and throws an error when more than one of the operations fails validation', async () => {
+      const operation2 = new OASOperation({
+        operationId: 'getHobbit',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'name',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            example: 'Frodo',
+          },
+        ],
+      });
+      const operation3 = new OASOperation({
+        operationId: 'getTomBombadil',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'times',
+            in: 'query',
+            example: 2,
+            schema: {
+              type: 'number',
+            },
+          },
+        ],
+      });
+      mockGetOperations.mockResolvedValue([operation2, operation3]);
+
+      mockExecute.mockResolvedValue({
+        url: 'https://www.lotr.com/walkIntoMorder',
+        status: 200,
+        ok: true,
+        body: {
+          data: [42],
+        },
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('2 operations failed');
+
+      expect(result).toEqual([
+        'getHobbit - default: Failed\n',
+        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data. Found 1 time\n',
+        'getTomBombadil - default: Failed\n',
+        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data. Found 1 time\n',
+      ]);
+    });
+
+    it('outputs the failure and throws an error when one of the responses returns a non-ok status', async () => {
+      const operation2 = new OASOperation({
+        operationId: 'getHobbit',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'name',
+            in: 'query',
+            schema: {
+              type: 'string',
+            },
+            example: 'Frodo',
+          },
+        ],
+      });
+      const operation3 = new OASOperation({
+        operationId: 'getTomBombadil',
+        responses: defaultResponses,
+        parameters: [
+          {
+            name: 'times',
+            in: 'query',
+            example: 2,
+            schema: {
+              type: 'number',
+            },
+          },
+        ],
+      });
+      mockGetOperations.mockResolvedValue([operation2, operation3]);
+
+      mockExecute.mockResolvedValueOnce({
+        url: 'https://www.lotr.com/walkIntoMorder',
+        status: 404,
+        ok: false,
+        body: {},
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('1 operation failed');
+
+      expect(result).toEqual([
+        'getHobbit - default: Failed\n',
+        '  - Response status code was a non 2XX value. Found 1 time\n',
+        'getTomBombadil - default: Succeeded\n',
+      ]);
+    });
+
+    it('outputs all the failures when one of the operations returns more than one validation failure', async () => {
+      mockExecute.mockResolvedValueOnce({
+        url: 'https://www.lotr.com/walkIntoMorder',
+        status: 200,
+        ok: true,
+        body: {
+          data: [
+            {
+              one: 'number',
+              two: 42,
+            },
+          ],
+        },
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('1 operation failed');
+
+      expect(result).toEqual([
+        'getHobbits - default: Failed\n',
+        '  - Actual type did not match schema. Schema type: number. Actual type: string. Path: body -> data -> one. Found 1 time\n',
+        '  - Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> data -> two. Found 1 time\n',
+      ]);
+    });
+
+    it('outputs any present warnings', async () => {
+      mockExecute.mockResolvedValueOnce({
+        url: 'https://www.lotr.com/walkIntoMorder',
+        status: 200,
+        ok: true,
+        body: {
+          data: [],
+        },
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await Positive.run(['http://urldoesnotmatter.com']);
+
+      expect(result).toEqual([
+        'getHobbits - default: Succeeded\n',
+        '  - Warning: This array was found to be empty and therefore could not be validated. Path: body -> data. Found 1 time\n',
+      ]);
+    });
+
+    it('prints repeated failures and warnings once with a count', async () => {
+      mockExecute.mockResolvedValueOnce({
+        url: 'https://www.lotr.com/walkIntoMorder',
+        status: 200,
+        ok: true,
+        body: {
+          data: [
+            {
+              one: 'not a number',
+            },
+            {
+              one: 1,
+            },
+            {
+              one: 'also not a number',
+            },
+          ],
+        },
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+
+      await expect(async () => {
+        await Positive.run(['http://urldoesnotmatter.com']);
+      }).rejects.toThrow('1 operation failed');
+
+      expect(result).toEqual([
+        'getHobbits - default: Failed\n',
+        '  - Actual type did not match schema. Schema type: number. Actual type: string. Path: body -> data -> one. Found 2 times\n',
+        '  - Warning: This object is missing non-required properties that were unable to be validated, including two. Path: body -> data. Found 3 times\n',
+      ]);
     });
   });
 });

--- a/test/setup-tests.ts
+++ b/test/setup-tests.ts
@@ -2,9 +2,13 @@ import { ValidationFailure } from '../src/validation-messages/failures';
 import { ValidationWarning } from '../src/validation-messages/warnings';
 
 expect.extend({
-  toContainValidationFailure(received: ValidationFailure[], argument: string) {
+  toContainValidationFailure(
+    received: Map<string, ValidationFailure>,
+    argument: string,
+  ) {
     let pass = false;
-    received
+    const failures = [...received.values()];
+    failures
       .map((validationFailure) => validationFailure.toString())
       .forEach((failureMessage) => {
         if (failureMessage === argument) {
@@ -16,7 +20,7 @@ expect.extend({
       return {
         message: (): string =>
           `expected ${this.utils.printReceived(
-            received.map((failure) => failure.toString()),
+            failures.map((failure) => failure.toString()),
           )} not to contain failure ${this.utils.printExpected(argument)}`,
         pass: true,
       };
@@ -24,14 +28,18 @@ expect.extend({
     return {
       message: (): string =>
         `expected ${this.utils.printReceived(
-          received.map((failure) => failure.toString()),
+          failures.map((failure) => failure.toString()),
         )} to contain failure ${this.utils.printExpected(argument)}`,
       pass: false,
     };
   },
-  toContainValidationWarning(received: ValidationWarning[], argument: string) {
+  toContainValidationWarning(
+    received: Map<string, ValidationWarning>,
+    argument: string,
+  ) {
     let pass = false;
-    received
+    const warnings = [...received.values()];
+    warnings
       .map((validationWarning) => validationWarning.toString())
       .forEach((warningMessage) => {
         if (warningMessage === argument) {
@@ -43,7 +51,7 @@ expect.extend({
       return {
         message: (): string =>
           `expected ${this.utils.printReceived(
-            received.map((warning) => warning.toString()),
+            warnings.map((warning) => warning.toString()),
           )} not to contain warning ${this.utils.printExpected(argument)}`,
         pass: true,
       };
@@ -51,7 +59,7 @@ expect.extend({
     return {
       message: (): string =>
         `expected ${this.utils.printReceived(
-          received.map((warning) => warning.toString()),
+          warnings.map((warning) => warning.toString()),
         )} to contain warning ${this.utils.printExpected(argument)}`,
       pass: false,
     };

--- a/test/utilities/validators/base-validator.test.ts
+++ b/test/utilities/validators/base-validator.test.ts
@@ -22,7 +22,7 @@ describe('BaseValidator', () => {
           ]);
 
           const failures = validator.failures;
-          expect(failures).toHaveLength(1);
+          expect(failures.size).toEqual(1);
           expect(failures).toContainValidationFailure(
             'Actual value is null but schema does not allow null values. Path: body -> facility -> id',
           );
@@ -44,7 +44,7 @@ describe('BaseValidator', () => {
           ]);
 
           const failures = validator.failures;
-          expect(failures).toHaveLength(1);
+          expect(failures.size).toEqual(1);
           expect(failures).toContainValidationFailure(
             'Actual value is null but schema does not allow null values. Path: body -> facility -> id',
           );
@@ -66,7 +66,7 @@ describe('BaseValidator', () => {
           ]);
 
           const failures = validator.failures;
-          expect(failures).toHaveLength(0);
+          expect(failures.size).toEqual(0);
         });
       });
     });
@@ -91,14 +91,14 @@ describe('BaseValidator', () => {
           validator.validateObjectAgainstSchema('This is a string', schema, [
             'test',
           ]);
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
       });
 
       describe('actual object is an array', () => {
         it('does not add a validation failure', () => {
           validator.validateObjectAgainstSchema([42, 58], schema, ['test']);
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
       });
 
@@ -109,7 +109,7 @@ describe('BaseValidator', () => {
             schema,
             ['test'],
           );
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
       });
     });
@@ -125,7 +125,7 @@ describe('BaseValidator', () => {
           validator.validateObjectAgainstSchema('This is a string', schema, [
             'test',
           ]);
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
 
         describe('schema expects an enum', () => {
@@ -164,7 +164,7 @@ describe('BaseValidator', () => {
                 'facility',
                 'id',
               ]);
-              expect(validator.failures).toHaveLength(0);
+              expect(validator.failures.size).toEqual(0);
             });
           });
 
@@ -214,7 +214,7 @@ describe('BaseValidator', () => {
             ]);
 
             const failures = validator.failures;
-            expect(failures).toHaveLength(1);
+            expect(failures.size).toEqual(1);
             expect(failures).toContainValidationFailure(
               'Actual type did not match schema. Schema type: string. Actual type: object. Path: body -> facility -> id',
             );
@@ -232,7 +232,7 @@ describe('BaseValidator', () => {
             ]);
 
             const failures = validator.failures;
-            expect(failures).toHaveLength(1);
+            expect(failures.size).toEqual(1);
             expect(failures).toContainValidationFailure(
               'Actual type did not match schema. Schema type: string. Actual type: object. Path: body -> facility -> id',
             );
@@ -254,7 +254,7 @@ describe('BaseValidator', () => {
             'facility',
             'lat',
           ]);
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
 
         describe('schema expects an enum', () => {
@@ -269,7 +269,7 @@ describe('BaseValidator', () => {
                 'facility',
                 'lat',
               ]);
-              expect(validator.failures).toHaveLength(0);
+              expect(validator.failures.size).toEqual(0);
             });
           });
 
@@ -343,7 +343,7 @@ describe('BaseValidator', () => {
             'facility',
             'lat',
           ]);
-          expect(validator.failures).toHaveLength(0);
+          expect(validator.failures.size).toEqual(0);
         });
 
         describe('schema expects an enum', () => {
@@ -358,7 +358,7 @@ describe('BaseValidator', () => {
                 'facility',
                 'lat',
               ]);
-              expect(validator.failures).toHaveLength(0);
+              expect(validator.failures.size).toEqual(0);
             });
           });
 
@@ -508,7 +508,7 @@ describe('BaseValidator', () => {
                 'body',
                 'numbers',
               ]);
-              expect(validator.failures).toHaveLength(0);
+              expect(validator.failures.size).toEqual(0);
             });
           });
 
@@ -689,7 +689,7 @@ describe('BaseValidator', () => {
           );
 
           const failures = validator.failures;
-          expect(failures).toHaveLength(1);
+          expect(failures.size).toEqual(1);
           expect(failures).toContainValidationFailure(
             'Actual type did not match schema. Schema type: string. Actual type: number. Path: body -> form -> value',
           );
@@ -699,9 +699,9 @@ describe('BaseValidator', () => {
           validator.validateObjectAgainstSchema({}, schema, ['body', 'form']);
 
           const warnings = validator.warnings;
-          expect(warnings).toHaveLength(1);
+          expect(warnings.size).toEqual(1);
           expect(warnings).toContainValidationWarning(
-            'Warning: This object is missing non-required parameters that were unable to be validated, including value. Path: body -> form',
+            'Warning: This object is missing non-required properties that were unable to be validated, including value. Path: body -> form',
           );
         });
 
@@ -713,9 +713,9 @@ describe('BaseValidator', () => {
           );
 
           const warnings = validator.warnings;
-          expect(warnings).toHaveLength(0);
+          expect(warnings.size).toEqual(0);
           expect(warnings).not.toContainValidationWarning(
-            'Warning: This object is missing non-required parameters that were unable to be validated, including value. Path: body -> form',
+            'Warning: This object is missing non-required properties that were unable to be validated, including value. Path: body -> form',
           );
         });
 
@@ -730,7 +730,7 @@ describe('BaseValidator', () => {
                 'body',
                 'form',
               ]);
-              expect(validator.failures).toHaveLength(0);
+              expect(validator.failures.size).toEqual(0);
             });
           });
 

--- a/test/utilities/validators/example-group-validator.test.ts
+++ b/test/utilities/validators/example-group-validator.test.ts
@@ -2,7 +2,7 @@ import ExampleGroup from '../../../src/utilities/example-group';
 import OASOperation from '../../../src/utilities/oas-operation';
 import { ExampleGroupValidator } from '../../../src/utilities/validators';
 
-describe('ParameterValidator', () => {
+describe('ExampleGroupValidator', () => {
   describe('validate', () => {
     describe('input parameters is missing a required parameter', () => {
       it('adds a validation failure', () => {
@@ -28,7 +28,7 @@ describe('ParameterValidator', () => {
         validator.validate();
 
         const failures = validator.failures;
-        expect(failures).toHaveLength(1);
+        expect(failures.size).toEqual(1);
         expect(failures).toContainValidationFailure(
           'Missing required parameters: [fit]',
         );
@@ -69,7 +69,7 @@ describe('ParameterValidator', () => {
           validator.validate();
 
           const failures = validator.failures;
-          expect(failures).toHaveLength(2);
+          expect(failures.size).toEqual(2);
           expect(failures).toContainValidationFailure(
             'Missing required parameters: [fit]',
           );
@@ -102,7 +102,7 @@ describe('ParameterValidator', () => {
       validator.validate();
 
       const failures = validator.failures;
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Actual type did not match schema. Schema type: string. Actual type: number. Path: parameters -> fit -> example',
       );
@@ -131,7 +131,7 @@ describe('ParameterValidator', () => {
       validator.validate();
 
       let failures = validator.failures;
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Missing required parameters: [fit]',
       );
@@ -140,7 +140,7 @@ describe('ParameterValidator', () => {
       validator.validate();
 
       failures = validator.failures;
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Missing required parameters: [fit]',
       );

--- a/test/utilities/validators/parameter-schema-validator.test.ts
+++ b/test/utilities/validators/parameter-schema-validator.test.ts
@@ -34,7 +34,7 @@ describe('ParameterSchemaValidator', () => {
 
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Parameter object must have either schema or content set, but not both. Path: parameters -> gryffindor',
       );
@@ -72,7 +72,7 @@ describe('ParameterSchemaValidator', () => {
 
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Parameter content object should only have one key. Path: parameters -> magical deliveries -> content',
       );
@@ -105,7 +105,7 @@ describe('ParameterSchemaValidator', () => {
 
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
       );
@@ -129,7 +129,7 @@ describe('ParameterSchemaValidator', () => {
 
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Parameter object must have either schema or content set, but not both. Path: parameters -> horcrux',
       );
@@ -160,7 +160,7 @@ describe('ParameterSchemaValidator', () => {
 
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         "The 'example' field is mutually exclusive of the 'examples' field, provide one or the other or neither, but not both. Path: parameters -> horcrux",
       );
@@ -190,9 +190,7 @@ describe('ParameterSchemaValidator', () => {
       const validator = new ParameterSchemaValidator(operation);
       validator.validate();
 
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(0);
+      expect(validator.failures.size).toEqual(0);
     });
 
     it('does not register a validation failure if schema is shaped correctly', () => {
@@ -214,9 +212,7 @@ describe('ParameterSchemaValidator', () => {
       const validator = new ParameterSchemaValidator(operation);
       validator.validate();
 
-      const failures = validator.failures;
-
-      expect(failures).toHaveLength(0);
+      expect(validator.failures.size).toEqual(0);
     });
 
     it('is idempotent', () => {
@@ -246,7 +242,7 @@ describe('ParameterSchemaValidator', () => {
 
       let failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
       );
@@ -255,7 +251,7 @@ describe('ParameterSchemaValidator', () => {
       validator.validate();
 
       failures = validator.failures;
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'The media type obejct in the content field is missing a schema object. Path: parameters -> magical deliveries -> content -> document/howler',
       );

--- a/test/utilities/validators/response-validator.test.ts
+++ b/test/utilities/validators/response-validator.test.ts
@@ -71,7 +71,7 @@ describe('ResponseValidator', () => {
       validator.validate();
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Response status code not present in schema. Actual status code: 500',
       );
@@ -91,7 +91,7 @@ describe('ResponseValidator', () => {
       validator.validate();
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Response content type not present in schema. Actual content type: text/csv',
       );
@@ -113,7 +113,7 @@ describe('ResponseValidator', () => {
       validator.validate();
       const failures = validator.failures;
 
-      expect(failures).toHaveLength(0);
+      expect(failures.size).toEqual(0);
     });
 
     it('is idempotent', () => {
@@ -130,7 +130,7 @@ describe('ResponseValidator', () => {
       validator.validate();
       let failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Response status code not present in schema. Actual status code: 500',
       );
@@ -139,7 +139,7 @@ describe('ResponseValidator', () => {
       validator.validate();
       failures = validator.failures;
 
-      expect(failures).toHaveLength(1);
+      expect(failures.size).toEqual(1);
       expect(failures).toContainValidationFailure(
         'Response status code not present in schema. Actual status code: 500',
       );


### PR DESCRIPTION
This PR is for [API-10201](https://vajira.max.gov/browse/API-10201). It removes duplicate validation messages from LOAST output by storing validation failures and warnings in maps instead of arrays in the validators. The ValidationMessage object was also updated to add a hash and a count. This way we can count the number of occurrences of each message.

I also updated the validator unit tests and the positive command unit tests. I also did a little refactoring of the positive command unit tests to group like-tests together and try to reuse one of the bigger json blobs that was duplicated over a few tests. I think these tests could use some more refactoring - I'll make a ticket for that work.