### PR TITLE
Api 12433/handle oauth2 security type

### DIFF
--- a/@types/swagger-client/index.d.ts
+++ b/@types/swagger-client/index.d.ts
@@ -43,13 +43,16 @@ declare module 'swagger-client' {
 
   interface ApiKey extends ValueObject {}
   interface BearerToken extends ValueObject {}
+  interface OauthToken {
+    token: { access_token: string }
+  }
 
   export interface Securities {
     authorized: Security;
   }
 
   export interface Security {
-    [securityKey: string]: ApiKey | BearerToken;
+    [securityKey: string]: ApiKey | BearerToken | OauthToken;
   }
 
   interface Opts {

--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -211,17 +211,17 @@ export default class Positive extends Command {
     for (const security of securities) {
       if (security.type === OASSecurityType.APIKEY) {
         const apiSecurityName = security.key;
-        const value =
+        const apiKeyValue =
           apiKey ??
           // eslint-disable-next-line no-await-in-loop
           (await cli.prompt('Please provide your API Key', {
             type: 'mask',
           }));
         if (!apiKey) {
-          apiKey = value;
+          apiKey = apiKeyValue;
         }
 
-        this.securityValues[apiSecurityName] = { value };
+        this.securityValues[apiSecurityName] = { value: apiKeyValue };
       }
       // Refactor logic to nest HTTP and OAUTH2 together in the same statement
       if (
@@ -230,23 +230,23 @@ export default class Positive extends Command {
         security.type === OASSecurityType.OAUTH2
       ) {
         const tokenSecurityName = security.key;
-        const value =
+        const tokenValue =
           token ??
           // eslint-disable-next-line no-await-in-loop
           (await cli.prompt('Please provide your token', {
             type: 'mask',
           }));
         if (!token) {
-          token = value;
+          token = tokenValue;
         }
 
         if (security.type === OASSecurityType.HTTP) {
-          this.securityValues[tokenSecurityName] = { value };
+          this.securityValues[tokenSecurityName] = { value: tokenValue };
         }
 
         if (security.type === OASSecurityType.OAUTH2) {
           this.securityValues[tokenSecurityName] = {
-            token: { access_token: value },
+            token: { access_token: tokenValue },
           };
         }
       }

--- a/src/commands/positive.ts
+++ b/src/commands/positive.ts
@@ -233,7 +233,7 @@ export default class Positive extends Command {
         const value =
           token ??
           // eslint-disable-next-line no-await-in-loop
-          (await cli.prompt('Please provide your bearer token', {
+          (await cli.prompt('Please provide your token', {
             type: 'mask',
           }));
         if (!token) {

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -446,12 +446,9 @@ describe('Positive', () => {
       await Positive.run(['./test/fixtures/securities/bearer_token_oas.json']);
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockPrompt).toHaveBeenCalledWith(
-        'Please provide your token',
-        {
-          type: 'mask',
-        },
-      );
+      expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
+        type: 'mask',
+      });
     });
 
     it('requests an oauth token when oauth type exists', async () => {

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -721,15 +721,12 @@ describe('Positive', () => {
       await Positive.run(['./test/fixtures/securities/bearer_token_oas.json']);
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockPrompt).toHaveBeenCalledWith(
-        'Please provide your bearer token',
-        {
-          type: 'mask',
-        },
-      );
+      expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
+        type: 'mask',
+      });
     });
 
-    it('requests an oauth token when oauth scheme exists', async () => {
+    it('requests an oauth token when oauth type exists', async () => {
       mockGetSecuritySchemes.mockResolvedValue([
         {
           key: 'boromir-security',
@@ -741,12 +738,38 @@ describe('Positive', () => {
       await Positive.run(['./test/fixtures/securities/oauth2_token_oas.json']);
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockPrompt).toHaveBeenCalledWith(
-        'Please provide your oauth2 token',
+      expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
+        type: 'mask',
+      });
+    });
+
+    it('handles multiple tokens of type bearer and oauth2', async () => {
+      mockGetSecuritySchemes.mockResolvedValue([
         {
-          type: 'mask',
+          key: 'boromir-bearer',
+          type: 'http',
+          description: 'one does simply walk into VA APIs',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
         },
-      );
+        {
+          key: 'boromir-prod-oauth',
+          type: 'oauth2',
+          description: 'one does simply walk into VA APIs',
+        },
+        {
+          key: 'boromir-sandbox-oauth',
+          type: 'oauth2',
+          description: 'one does simply walk into VA APIs',
+        },
+      ]);
+
+      await Positive.run(['./test/fixtures/securities/oauth2_token_oas.json']);
+
+      expect(mockPrompt).toHaveBeenCalledTimes(1);
+      expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
+        type: 'mask',
+      });
     });
 
     it('requests authorization for each security type in the spec', async () => {

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -738,7 +738,7 @@ describe('Positive', () => {
         },
       ]);
 
-      await Positive.run(['./test/fixtures/securities/bearer_token_oas.json']);
+      await Positive.run(['./test/fixtures/securities/oauth2_token_oas.json']);
 
       expect(mockPrompt).toHaveBeenCalled();
       expect(mockPrompt).toHaveBeenCalledWith(

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -683,6 +683,7 @@ describe('Positive', () => {
   describe('promptForSecurityValues', () => {
     beforeEach(() => {
       mockPrompt.mockReset();
+      mockPrompt.mockResolvedValue('apikeyOrToken');
       mockGetSecuritySchemes.mockReset();
     });
 
@@ -697,9 +698,7 @@ describe('Positive', () => {
         },
       ]);
 
-      await Positive.run([
-        './test/fixtures/securities/spec_level_security_oas.json',
-      ]);
+      await Positive.run(['https://url-does-not-matter.com']);
 
       expect(mockPrompt).toHaveBeenCalled();
       expect(mockPrompt).toHaveBeenCalledWith('Please provide your API Key', {
@@ -718,7 +717,7 @@ describe('Positive', () => {
         },
       ]);
 
-      await Positive.run(['./test/fixtures/securities/bearer_token_oas.json']);
+      await Positive.run(['https://url-does-not-matter.com']);
 
       expect(mockPrompt).toHaveBeenCalled();
       expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
@@ -735,7 +734,7 @@ describe('Positive', () => {
         },
       ]);
 
-      await Positive.run(['./test/fixtures/securities/oauth2_token_oas.json']);
+      await Positive.run(['https://url-does-not-matter.com']);
 
       expect(mockPrompt).toHaveBeenCalled();
       expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
@@ -743,28 +742,23 @@ describe('Positive', () => {
       });
     });
 
-    it('handles multiple tokens of type bearer and oauth2', async () => {
+    it('only propmts once if OAS contains both http bearer and oauth2 security schemes', async () => {
       mockGetSecuritySchemes.mockResolvedValue([
         {
-          key: 'boromir-bearer',
+          key: 'boromir-security',
           type: 'http',
           description: 'one does simply walk into VA APIs',
           scheme: 'bearer',
           bearerFormat: 'JWT',
         },
         {
-          key: 'boromir-prod-oauth',
-          type: 'oauth2',
-          description: 'one does simply walk into VA APIs',
-        },
-        {
-          key: 'boromir-sandbox-oauth',
+          key: 'faramir-security',
           type: 'oauth2',
           description: 'one does simply walk into VA APIs',
         },
       ]);
 
-      await Positive.run(['./test/fixtures/securities/oauth2_token_oas.json']);
+      await Positive.run(['https://url-does-not-matter.com']);
 
       expect(mockPrompt).toHaveBeenCalledTimes(1);
       expect(mockPrompt).toHaveBeenCalledWith('Please provide your token', {
@@ -791,7 +785,7 @@ describe('Positive', () => {
         },
       ]);
 
-      await Positive.run(['./test/fixtures/securities/mixed_levels_oas.json']);
+      await Positive.run(['https://url-does-not-matter.com']);
 
       expect(mockPrompt).toHaveBeenCalled();
       expect(mockPrompt).toHaveBeenCalledTimes(2);
@@ -800,11 +794,7 @@ describe('Positive', () => {
     it('throws an error if no security schemes are defined in the component object', async () => {
       mockGetSecuritySchemes.mockResolvedValue([]);
 
-      await expect(
-        Positive.run([
-          './test/fixtures/securities/no_security_schemes_oas.json',
-        ]),
-      ).rejects
+      await expect(Positive.run(['https://url-does-not-matter.com'])).rejects
         .toThrow(`The following security requirements exist but no corresponding security scheme exists on a components object: boromir-security,faramir-security.
   See more at: https://swagger.io/specification/#security-requirement-object`);
 

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -729,6 +729,26 @@ describe('Positive', () => {
       );
     });
 
+    it('requests an oauth token when oauth scheme exists', async () => {
+      mockGetSecuritySchemes.mockResolvedValue([
+        {
+          key: 'boromir-security',
+          type: 'oauth2',
+          description: 'one does simply walk into VA APIs',
+        },
+      ]);
+
+      await Positive.run(['./test/fixtures/securities/bearer_token_oas.json']);
+
+      expect(mockPrompt).toHaveBeenCalled();
+      expect(mockPrompt).toHaveBeenCalledWith(
+        'Please provide your oauth2 token',
+        {
+          type: 'mask',
+        },
+      );
+    });
+
     it('requests authorization for each security type in the spec', async () => {
       mockGetSecuritySchemes.mockResolvedValue([
         {

--- a/test/fixtures/securities/oauth2_token_oas.json
+++ b/test/fixtures/securities/oauth2_token_oas.json
@@ -1,0 +1,10652 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "US Core R4",
+    "description": "In adherence to changes per the [21st Century Cures Act](https://www.federalregister.gov/documents/2020/05/01/2020-07419/21st-century-cures-act-interoperability-information-blocking-and-the-onc-health-it-certification#h-13), the Veteran Health API profile follows the US Core Implementation Guide. Per these regulations, we will be adding new FHIR resources to this tab as they are available.\n\nThis service is compliant with the FHIR US Core Implementation Guide. This service does not provide or replace the consultation, guidance, or care of a health care professional or other qualified provider. This service provides a supplement for informational and educational purposes only. Health care professionals and other qualified providers should continue to consult authoritative records when making decisions.",
+    "version": "v1"
+  },
+  "externalDocs": {
+    "description": "US Core Implementation Guide",
+    "url": "https://hl7.org/fhir/us/core/STU4/index.html"
+  },
+  "servers": [
+    {
+      "url": "https://sandbox-api.va.gov/services/fhir/{version}/r4",
+      "description": "Sandbox",
+      "variables": {
+        "version": {
+          "default": "v0"
+        }
+      }
+    },
+    {
+      "url": "https://api.va.gov/services/fhir/{version}/r4",
+      "description": "Production",
+      "variables": {
+        "version": {
+          "default": "v0"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "OauthFlowSandbox": [
+        "patient/Condition.read"
+      ]
+    },
+    {
+      "OauthFlowProduction": [
+        "patient/Condition.read"
+      ]
+    }
+  ],
+  "paths": {
+    "/Condition": {
+      "get": {
+        "tags": [
+          "Condition"
+        ],
+        "summary": "Condition Search",
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-condition.html",
+        "operationId": "conditionSearch",
+        "security": [
+          {
+            "OauthFlowSandbox": [
+              "patient/Condition.read"
+            ]
+          },
+          {
+            "OauthFlowProduction": [
+              "patient/Condition.read"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "patient",
+            "in": "query",
+            "description": "The Integration Control Number (ICN) assigned by the Master Patient Index (MPI) that indicates the patient who the condition record is associated with.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1011537977V693883"
+          },
+          {
+            "name": "_id",
+            "in": "query",
+            "description": "The logical id of the resource. Once assigned, this value never changes.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "identifier",
+            "in": "query",
+            "description": "The logical identifier of the resource. Once assigned, this value never changes.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "The category the condition record belongs to. Can be used to distinguish between health concerns and problems. [Condition Category Codes](https://www.hl7.org/fhir/valueset-condition-category.html)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "clinical-status",
+            "in": "query",
+            "description": "Indicates the clinical state of the condition described by the record, taking prior conditions into account.[Condition Clinical Status Codes](https://hl7.org/fhir/r4/valueset-condition-clinical.html)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The page number being requested.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "_count",
+            "in": "query",
+            "description": "The number of resources that should be returned in a single page. The maximum count size is 100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Record found",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConditionBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "example": {
+                    "message": "API rate limit exceeded"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "content": {
+              "application/fhir+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperationOutcome"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Address": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "use": {
+            "type": "string",
+            "enum": [
+              "home",
+              "work",
+              "temp",
+              "old",
+              "billing"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "postal",
+              "physical",
+              "both"
+            ]
+          },
+          "text": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "line": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "city": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "district": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "state": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "postalCode": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "country": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Address"
+      },
+      "Age": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "value": {
+            "type": "number"
+          },
+          "comparator": {
+            "pattern": "(<|<=|>=|>)",
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          }
+        },
+        "description": "http://hl7.org/fhir/R4/datatypes.html#Age"
+      },
+      "AllergyIntolerance": {
+        "required": [
+          "code",
+          "patient",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "clinicalStatus": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "verificationStatus": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "allergy",
+              "intolerance"
+            ]
+          },
+          "category": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "food",
+                "medication",
+                "environment",
+                "biologic"
+              ]
+            }
+          },
+          "criticality": {
+            "type": "string",
+            "enum": [
+              "low",
+              "high",
+              "unable-to-assess"
+            ]
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "patient": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "onsetDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "onsetAge": {
+            "$ref": "#/components/schemas/Age"
+          },
+          "onsetPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "onsetRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "onsetString": {
+            "type": "string"
+          },
+          "recordedDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "recorder": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "asserter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "lastOccurence": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "reaction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AllergyIntoleranceReaction"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-allergyintolerance.html",
+        "example": {
+          "resourceType": "AllergyIntolerance",
+          "id": "I2-6F9A021B07D553C88CCEB49A694D4AD9",
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                "code": "confirmed"
+              }
+            ]
+          },
+          "type": "allergy",
+          "category": [
+            "food"
+          ],
+          "patient": {
+            "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/1017283148V813263",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "onsetDateTime": "1995-04-30T01:15:52Z",
+          "note": [
+            {
+              "time": "1995-04-30T01:15:52Z",
+              "text": "Allergy to peanuts"
+            }
+          ],
+          "reaction": [
+            {
+              "manifestation": [
+                {
+                  "coding": [
+                    {
+                      "system": "urn:oid:2.16.840.1.113883.6.233",
+                      "code": "2000001",
+                      "display": "Inflammation of Skin"
+                    }
+                  ],
+                  "text": "Inflammation of Skin"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "AllergyIntoleranceBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AllergyIntoleranceEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/AllergyIntolerance?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/AllergyIntolerance?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/AllergyIntolerance?patient=1017283148V813263&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/r4/v0/AllergyIntolerance/I2-6F9A021B07D553C88CCEB49A694D4AD9",
+              "resource": {
+                "resourceType": "AllergyIntolerance",
+                "id": "I2-6F9A021B07D553C88CCEB49A694D4AD9",
+                "clinicalStatus": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                      "code": "active"
+                    }
+                  ]
+                },
+                "verificationStatus": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                      "code": "confirmed"
+                    }
+                  ]
+                },
+                "type": "allergy",
+                "category": [
+                  "food"
+                ],
+                "patient": {
+                  "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/1017283148V813263",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "onsetDateTime": "1995-04-30T01:15:52Z",
+                "note": [
+                  {
+                    "time": "1995-04-30T01:15:52Z",
+                    "text": "Allergy to peanuts"
+                  }
+                ],
+                "reaction": [
+                  {
+                    "manifestation": [
+                      {
+                        "coding": [
+                          {
+                            "system": "urn:oid:2.16.840.1.113883.6.233",
+                            "code": "2000001",
+                            "display": "Inflammation of Skin"
+                          }
+                        ],
+                        "text": "Inflammation of Skin"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "AllergyIntoleranceEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/AllergyIntolerance"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "AllergyIntoleranceReaction": {
+        "required": [
+          "manifestation"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "substance": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "manifestation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "onset": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "mild",
+              "moderate",
+              "severe"
+            ]
+          },
+          "exposureRoute": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          }
+        }
+      },
+      "Annotation": {
+        "required": [
+          "text"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "authorReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "authorString": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "time": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "text": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Annotation"
+      },
+      "Appointment": {
+        "required": [
+          "participant",
+          "resourceType",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "proposed",
+              "pending",
+              "booked",
+              "arrived",
+              "fulfilled",
+              "cancelled",
+              "noshow",
+              "entered-in-error",
+              "checked-in",
+              "waitlist"
+            ]
+          },
+          "cancelationReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "serviceCategory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "serviceType": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "specialty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "appointmentType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "reasonCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "reasonReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "priority": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "supportingInformation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "start": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "end": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "minutesDuration": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "slot": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "created": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "comment": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "patientInstruction": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "participant": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentParticipant"
+            }
+          },
+          "requestedPeriod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Period"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/appointment.html",
+        "example": {
+          "resourceType": "Appointment",
+          "id": "I2-09PJ067B07D553B93JCEB49A0JP12QW9",
+          "status": "cancelled",
+          "description": "Scheduled Visit",
+          "start": "2006-06-30T17:00:00Z",
+          "participant": [
+            {
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/v3/ParticipationType",
+                      "code": "PART",
+                      "display": "Participation"
+                    }
+                  ],
+                  "text": "Participation"
+                }
+              ],
+              "actor": {
+                "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/185601V825290",
+                "display": "VETERAN,JOHN Q"
+              },
+              "required": "required",
+              "status": "accepted"
+            },
+            {
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/v3/ParticipationType",
+                      "code": "PART",
+                      "display": "Participation"
+                    }
+                  ],
+                  "text": "Participation"
+                }
+              ],
+              "actor": {
+                "reference": "https://sandbox-api.va.gov/services/r4/v0/Location/I2-LPMZXCR5691VTFT8P0P0123B90GY34TT",
+                "display": "ZZZTG SURG POD SCHEULLER COBI"
+              },
+              "required": "required",
+              "status": "accepted"
+            }
+          ]
+        }
+      },
+      "AppointmentBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppointmentEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Appointment?patient=185601V825290&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Appointment?patient=185601V825290&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Appointment?patient=185601V825290&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/r4/v0/Appointment/I2-09PJ067B07D553B93JCEB49A0JP12QW9",
+              "resource": {
+                "resourceType": "Appointment",
+                "id": "I2-09PJ067B07D553B93JCEB49A0JP12QW9",
+                "status": "cancelled",
+                "description": "Scheduled Visit",
+                "start": "2006-06-30T17:00:00Z",
+                "participant": [
+                  {
+                    "type": [
+                      {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/v3/ParticipationType",
+                            "code": "PART",
+                            "display": "Participation"
+                          }
+                        ],
+                        "text": "Participation"
+                      }
+                    ],
+                    "actor": {
+                      "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/185601V825290",
+                      "display": "VETERAN,JOHN Q"
+                    },
+                    "required": "required",
+                    "status": "accepted"
+                  },
+                  {
+                    "type": [
+                      {
+                        "coding": [
+                          {
+                            "system": "http://hl7.org/fhir/v3/ParticipationType",
+                            "code": "PART",
+                            "display": "Participation"
+                          }
+                        ],
+                        "text": "Participation"
+                      }
+                    ],
+                    "actor": {
+                      "reference": "https://sandbox-api.va.gov/services/r4/v0/Location/I2-LPMZXCR5691VTFT8P0P0123B90GY34TT",
+                      "display": "ZZZTG SURG POD SCHEULLER COBI"
+                    },
+                    "required": "required",
+                    "status": "accepted"
+                  }
+                ]
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "AppointmentEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Appointment"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "AppointmentParticipant": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "actor": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "required": {
+            "type": "string",
+            "enum": [
+              "required",
+              "optional",
+              "information-only"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "accepted",
+              "declined",
+              "tentative",
+              "needs-action"
+            ]
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        }
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "contentType": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "data": {
+            "pattern": "(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+",
+            "type": "string"
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "size": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "hash": {
+            "pattern": "(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+",
+            "type": "string"
+          },
+          "title": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "creation": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Attachment"
+      },
+      "BundleLink": {
+        "required": [
+          "relation",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "about",
+              "alternate",
+              "appendix",
+              "archives",
+              "author",
+              "blocked-by",
+              "bookmark",
+              "canonical",
+              "chapter",
+              "cite-as",
+              "collection",
+              "contents",
+              "convertedFrom",
+              "copyright",
+              "create-form",
+              "current",
+              "describedby",
+              "describes",
+              "disclosure",
+              "dns-prefetch",
+              "duplicate",
+              "edit",
+              "edit-form",
+              "edit-media",
+              "enclosure",
+              "first",
+              "glossary",
+              "help",
+              "hosts",
+              "hub",
+              "icon",
+              "index",
+              "intervalAfter",
+              "intervalBefore",
+              "intervalContains",
+              "intervalDisjoint",
+              "intervalDuring",
+              "intervalEquals",
+              "intervalFinishedBy",
+              "intervalFinishes",
+              "intervalln",
+              "intervalMeets",
+              "intervalMetBy",
+              "intervalOverlappedBy",
+              "intervalOverlaps",
+              "intervalStartedBy",
+              "intervalStarts",
+              "item",
+              "last",
+              "latest-version",
+              "license",
+              "lrdd",
+              "memento",
+              "monitor",
+              "monitor-group",
+              "next",
+              "next-archive",
+              "nofollow",
+              "noreferrer",
+              "original",
+              "payment",
+              "pingback",
+              "preconnect",
+              "predecessor-version",
+              "prefetch",
+              "preload",
+              "prerender",
+              "prev",
+              "preview",
+              "previous",
+              "prev-archive",
+              "privacy-policy",
+              "profile",
+              "related",
+              "restconf",
+              "replies",
+              "search",
+              "section",
+              "self",
+              "service",
+              "start",
+              "stylesheet",
+              "subsection",
+              "successor-version",
+              "tag",
+              "terms-of-service",
+              "timegate",
+              "timemap",
+              "type",
+              "up",
+              "version-history",
+              "via",
+              "webmention",
+              "working-copy",
+              "working-copy-of"
+            ]
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        }
+      },
+      "CapabilityResource": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "profile": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "supportedProfile": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "interaction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceInteraction"
+            }
+          },
+          "versioning": {
+            "type": "string",
+            "enum": [
+              "no-version",
+              "versioned",
+              "versioned-update"
+            ]
+          },
+          "readHistory": {
+            "type": "boolean"
+          },
+          "updateCreate": {
+            "type": "boolean"
+          },
+          "conditionalCreate": {
+            "type": "boolean"
+          },
+          "conditionalRead": {
+            "type": "string",
+            "enum": [
+              "not-supported",
+              "modified-since",
+              "not-match",
+              "full-support"
+            ]
+          },
+          "conditionalUpdate": {
+            "type": "boolean"
+          },
+          "conditionalDelete": {
+            "type": "string",
+            "enum": [
+              "not-supported",
+              "single",
+              "multiple"
+            ]
+          },
+          "referencePolicy": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "literal",
+                "logical",
+                "resolves",
+                "enforced",
+                "local"
+              ]
+            }
+          },
+          "searchInclude": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "searchRevInclude": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "searchParam": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchParam"
+            }
+          },
+          "operation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Operation"
+            }
+          }
+        }
+      },
+      "CapabilityStatement": {
+        "required": [
+          "date",
+          "fhirVersion",
+          "format",
+          "kind",
+          "resourceType",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "version": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "title": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "retired",
+              "unknown"
+            ]
+          },
+          "experimental": {
+            "type": "boolean"
+          },
+          "date": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "publisher": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactDetail"
+            }
+          },
+          "description": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "useContext": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UsageContext"
+            }
+          },
+          "jurisdiction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "purpose": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "copyright": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "instance",
+              "capability",
+              "requirements"
+            ]
+          },
+          "instantiates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "imports": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "software": {
+            "$ref": "#/components/schemas/Software"
+          },
+          "implementation": {
+            "$ref": "#/components/schemas/Implementation"
+          },
+          "fhirVersion": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "format": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "patchFormat": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "implementationGuide": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rest": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rest"
+            }
+          },
+          "messaging": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Messaging"
+            }
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/capabilitystatement.html",
+        "example": {
+          "resourceType": "CapabilityStatement",
+          "id": "example-api-capability",
+          "version": "1.23.456",
+          "name": "API Management Platform | Example - US Core",
+          "title": "API Management Platform | Example - US Core",
+          "status": "active",
+          "experimental": false,
+          "date": "2021-11-10T17:00:00Z",
+          "publisher": "Department of Veterans Affairs",
+          "contact": [
+            {
+              "name": "Example Contact",
+              "telecom": [
+                {
+                  "system": "email",
+                  "value": "example.email@foo.com"
+                }
+              ]
+            }
+          ],
+          "description": "Read and search support for FHIR resources.",
+          "kind": "capability",
+          "software": {
+            "name": "gov.va.api.examples:example-app",
+            "version": "1.23.456",
+            "releaseDate": "2021-11-01T17:00:00Z"
+          },
+          "implementation": {
+            "description": "API Management Platform | Example - US Core",
+            "url": "https://sandbox-api.va.gov/services/fhir/r4"
+          },
+          "fhirVersion": "4.0.1",
+          "format": [
+            "application/json",
+            "application/fhir+json"
+          ],
+          "rest": [
+            {
+              "mode": "server",
+              "security": {
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "token",
+                        "valueUri": "https://sandbox-api.va.gov/example/token"
+                      },
+                      {
+                        "url": "authorize",
+                        "valueUri": "https://sandbox-api.va.gov/example/authorize"
+                      },
+                      {
+                        "url": "manage",
+                        "valueUri": "https://sandbox-api.va.gov/example/manage"
+                      },
+                      {
+                        "url": "revoke",
+                        "valueUri": "https://sandbox-api.va.gov/example/revoke"
+                      }
+                    ],
+                    "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris"
+                  }
+                ],
+                "cors": true,
+                "service": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/restful-security-service",
+                        "code": "SMART-on-FHIR",
+                        "display": "SMART-on-FHIR"
+                      }
+                    ],
+                    "text": "SMART-on-FHIR"
+                  }
+                ],
+                "description": "http://docs.smarthealthit.org/"
+              },
+              "resource": [
+                {
+                  "type": "Example Resource",
+                  "profile": "http://example-resource-profile.com",
+                  "interaction": [
+                    {
+                      "code": "search-type",
+                      "documentation": "Example search interaction."
+                    },
+                    {
+                      "code": "read",
+                      "documentation": "Example read interaction."
+                    }
+                  ],
+                  "versioning": "no-version",
+                  "referencePolicy": [
+                    "literal"
+                  ],
+                  "searchParam": [
+                    {
+                      "name": "example_param",
+                      "type": "token"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "ClassHistory": {
+        "required": [
+          "class",
+          "period"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "class": {
+            "$ref": "#/components/schemas/Coding"
+          }
+        }
+      },
+      "CodeableConcept": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "coding": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Coding"
+            }
+          },
+          "text": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#CodeableConcept"
+      },
+      "CodeFilter": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "path": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "searchParam": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "valueSet": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "code": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Coding"
+            }
+          }
+        }
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "version": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "display": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "userSelected": {
+            "type": "boolean"
+          }
+        },
+        "description": "https://hl7.org/fhir/R4/datatypes.html#Coding"
+      },
+      "Communication": {
+        "required": [
+          "language"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "language": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "preferred": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Component": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueQuantity": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueString": {
+            "type": "string"
+          },
+          "valueBoolean": {
+            "type": "boolean"
+          },
+          "valueInteger": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "valueRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "valueRatio": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "valueSampledData": {
+            "$ref": "#/components/schemas/SampledData"
+          },
+          "valueTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          },
+          "valueDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "valuePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "dataAbsentReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "interpretation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "referenceRange": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReferenceRange"
+            }
+          }
+        }
+      },
+      "Condition": {
+        "required": [
+          "category",
+          "code",
+          "resourceType",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "clinicalStatus": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "verificationStatus": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "category": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "severity": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "bodySite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "onsetDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "onsetAge": {
+            "$ref": "#/components/schemas/Age"
+          },
+          "onsetPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "onsetRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "onsetString": {
+            "type": "string"
+          },
+          "abatementDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "abatementAge": {
+            "$ref": "#/components/schemas/Age"
+          },
+          "abatementPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "abatementRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "abatementString": {
+            "type": "string"
+          },
+          "recordedDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "recorder": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "asserter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "stage": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionStage"
+            }
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionEvidence"
+            }
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-condition.html",
+        "example": {
+          "resourceType": "Condition",
+          "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+          "clinicalStatus": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/R4/valueset-condition-clinical.html",
+                "code": "active"
+              }
+            ]
+          },
+          "verificationStatus": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/R4/valueset-condition-ver-status.html",
+                "code": "unconfirmed"
+              }
+            ]
+          },
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "https://hl7.org/fhir/us/core/STU4/ValueSet-us-core-condition-category.html",
+                  "code": "problem-list-item"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://www.snomed.org/snomed-ct",
+                "code": "38341003",
+                "display": "Hypertension"
+              }
+            ],
+            "text": "Hypertension"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1017283148V813263",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "onsetDateTime": "2013-04-15T01:15:52Z",
+          "recordedDate": "2013-04-14"
+        }
+      },
+      "ConditionBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConditionEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition?patient=1017283148V813263&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Condition/I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+              "resource": {
+                "resourceType": "Condition",
+                "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+                "clinicalStatus": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/R4/valueset-condition-clinical.html",
+                      "code": "active"
+                    }
+                  ]
+                },
+                "verificationStatus": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/R4/valueset-condition-ver-status.html",
+                      "code": "unconfirmed"
+                    }
+                  ]
+                },
+                "category": [
+                  {
+                    "coding": [
+                      {
+                        "system": "https://hl7.org/fhir/us/core/STU4/ValueSet-us-core-condition-category.html",
+                        "code": "problem-list-item"
+                      }
+                    ]
+                  }
+                ],
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://www.snomed.org/snomed-ct",
+                      "code": "38341003",
+                      "display": "Hypertension"
+                    }
+                  ],
+                  "text": "Hypertension"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1017283148V813263",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "onsetDateTime": "2013-04-15T01:15:52Z",
+                "recordedDate": "2013-04-14"
+              }
+            }
+          ]
+        }
+      },
+      "ConditionEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Condition"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "ConditionEvidence": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "code": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "detail": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        }
+      },
+      "ConditionStage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "summary": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "assessment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          }
+        }
+      },
+      "ContactDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#ContactDetail"
+      },
+      "ContactPoint": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "system": {
+            "type": "string",
+            "enum": [
+              "phone",
+              "fax",
+              "email",
+              "pager",
+              "other",
+              "url",
+              "sms"
+            ]
+          },
+          "value": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "use": {
+            "type": "string",
+            "enum": [
+              "home",
+              "work",
+              "temp",
+              "old",
+              "mobile"
+            ]
+          },
+          "rank": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        },
+        "description": "https://hl7.org/fhir/R4/datatypes.html#ContactPoint"
+      },
+      "Contributor": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string",
+            "enum": [
+              "author",
+              "editor",
+              "reviewer",
+              "endorser"
+            ]
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactDetail"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#contributor"
+      },
+      "DataRequirement": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "profile": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subjectCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "subjectReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "mustSupport": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "codeFilter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeFilter"
+            }
+          },
+          "dateFilter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilter"
+            }
+          },
+          "limit": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Sort"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#DataRequirement"
+      },
+      "DateFilter": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "path": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "searchParam": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "valueDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "valuePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "valueDuration": {
+            "$ref": "#/components/schemas/Duration"
+          }
+        }
+      },
+      "Device": {
+        "required": [
+          "patient",
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "definition": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "udiCarrier": {
+            "$ref": "#/components/schemas/UniqueDeviceIdentifier"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive",
+              "entered-in-error",
+              "unknown"
+            ]
+          },
+          "statusReason": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "distinctIdentifier": {
+            "type": "string"
+          },
+          "manufacturer": {
+            "type": "string"
+          },
+          "manufactureDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "expirationDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "lotNumber": {
+            "type": "string"
+          },
+          "serialNumber": {
+            "type": "string"
+          },
+          "deviceName": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceName"
+            }
+          },
+          "modelNumber": {
+            "type": "string"
+          },
+          "partNumber": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "specialization": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceSpecialization"
+            }
+          },
+          "version": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceVersion"
+            }
+          },
+          "property": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceProperty"
+            }
+          },
+          "patient": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "safety": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        },
+        "description": "http://hl7.org/fhir/us/core/StructureDefinition-us-core-implantable-device.html",
+        "example": {
+          "resourceType": "Device",
+          "id": "I2-526QWVIAZHOZHCMERY7CQDV7UEAYPJXR4SASZH2FJNN3OUGOZ3QA0000",
+          "manufacturer": "BOSTON SCIENTIFIC",
+          "lotNumber": "A19031",
+          "serialNumber": "819569",
+          "deviceName": [
+            {
+              "name": "L331",
+              "type": "model-name"
+            },
+            {
+              "name": "PACEMAKER",
+              "type": "user-friendly-name"
+            }
+          ],
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "53350007",
+                "display": "Prosthesis, device (physical object)"
+              }
+            ],
+            "text": "Prosthesis, device (physical object)"
+          },
+          "patient": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/2000163",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "owner": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-DJAYYHV2W7ISKUFTCHH4XSGVP4000000",
+            "display": "JONESBORO VA CLINIC"
+          }
+        }
+      },
+      "DeviceBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Device?patient=2000163&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Device?patient=2000163&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Device?patient=2000163&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Device/I2-526QWVIAZHOZHCMERY7CQDV7UEAYPJXR4SASZH2FJNN3OUGOZ3QA0000",
+              "resource": {
+                "resourceType": "Device",
+                "id": "I2-526QWVIAZHOZHCMERY7CQDV7UEAYPJXR4SASZH2FJNN3OUGOZ3QA0000",
+                "manufacturer": "BOSTON SCIENTIFIC",
+                "lotNumber": "A19031",
+                "serialNumber": "819569",
+                "deviceName": [
+                  {
+                    "name": "L331",
+                    "type": "model-name"
+                  },
+                  {
+                    "name": "PACEMAKER",
+                    "type": "user-friendly-name"
+                  }
+                ],
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "53350007",
+                      "display": "Prosthesis, device (physical object)"
+                    }
+                  ],
+                  "text": "Prosthesis, device (physical object)"
+                },
+                "patient": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/2000163",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "owner": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-DJAYYHV2W7ISKUFTCHH4XSGVP4000000",
+                  "display": "JONESBORO VA CLINIC"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "DeviceEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Device"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "DeviceName": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "udi-label-name",
+              "user-friendly-name",
+              "patient-reported-name",
+              "manufacturer-name",
+              "model-name",
+              "other"
+            ]
+          }
+        }
+      },
+      "DeviceProperty": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueQuantity": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Quantity"
+            }
+          },
+          "valueCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          }
+        }
+      },
+      "DeviceSpecialization": {
+        "required": [
+          "systemType"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "systemType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "DeviceVersion": {
+        "required": [
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "component": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "Diagnosis": {
+        "required": [
+          "condition",
+          "modifierExtension"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "condition": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "use": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "rank": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DiagnosticReport": {
+        "required": [
+          "category",
+          "code",
+          "issued",
+          "resourceType",
+          "status",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "amended",
+              "appended",
+              "cancelled",
+              "corrected",
+              "entered-in-error",
+              "final",
+              "partial",
+              "preliminary",
+              "registered",
+              "unknown"
+            ]
+          },
+          "category": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "effectiveDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "effectivePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "issued": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "performer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "resultsInterpreter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "specimen": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "imagingStudy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "media": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiagnosticReportMedia"
+            }
+          },
+          "conclusion": {
+            "type": "string"
+          },
+          "conclusionCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "presentedForm": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Attachment"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-diagnosticreport-lab.html",
+        "example": {
+          "resourceType": "DiagnosticReport",
+          "id": "I2-M2QUOOXL3O73NUZCB7HEOVQ2GAGQFOATAYXW5FMU3I57IYQDE6RQ0000",
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                  "code": "LAB",
+                  "display": "Laboratory"
+                }
+              ],
+              "text": "Laboratory"
+            }
+          ],
+          "code": {
+            "text": "panel"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883",
+            "display": "Mr. Aurelio Cruickshank"
+          },
+          "effectiveDateTime": "2020-07-20T01:15:52Z",
+          "issued": "2020-07-20T01:15:52Z",
+          "result": [
+            {
+              "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-6LCCQZ7GTK5X3P54BHCIZ2Q75IFIV5ZK7F4OUU7JUP72XENSV5ZQ0000",
+              "display": "WBC COUNT"
+            },
+            {
+              "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-MC6GKVYKVRED3ZLSG4EPUW5XMRLGOY46XCIGKDV4KNEBV5Y52NZA0000",
+              "display": "HEMOGLOBIN"
+            }
+          ]
+        }
+      },
+      "DiagnosticReportBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiagnosticReportEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/DiagnosticReport?patient=1011537977V693883&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/DiagnosticReport?patient=1011537977V693883&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/DiagnosticReport?patient=1011537977V693883&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/DiagnosticReport/I2-M2QUOOXL3O73NUZCB7HEOVQ2GAGQFOATAYXW5FMU3I57IYQDE6RQ0000",
+              "resource": {
+                "resourceType": "DiagnosticReport",
+                "id": "I2-M2QUOOXL3O73NUZCB7HEOVQ2GAGQFOATAYXW5FMU3I57IYQDE6RQ0000",
+                "status": "final",
+                "category": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                        "code": "LAB",
+                        "display": "Laboratory"
+                      }
+                    ],
+                    "text": "Laboratory"
+                  }
+                ],
+                "code": {
+                  "text": "panel"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883",
+                  "display": "Mr. Aurelio Cruickshank"
+                },
+                "effectiveDateTime": "2020-07-20T01:15:52Z",
+                "issued": "2020-07-20T01:15:52Z",
+                "result": [
+                  {
+                    "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-6LCCQZ7GTK5X3P54BHCIZ2Q75IFIV5ZK7F4OUU7JUP72XENSV5ZQ0000",
+                    "display": "WBC COUNT"
+                  },
+                  {
+                    "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Observation/I2-MC6GKVYKVRED3ZLSG4EPUW5XMRLGOY46XCIGKDV4KNEBV5Y52NZA0000",
+                    "display": "HEMOGLOBIN"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "DiagnosticReportEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/DiagnosticReport"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "DiagnosticReportMedia": {
+        "required": [
+          "link"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "comment": {
+            "type": "string"
+          },
+          "link": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "Document": {
+        "required": [
+          "mode",
+          "profile"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "producer",
+              "consumer"
+            ]
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "profile": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        }
+      },
+      "Dosage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "sequence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "text": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "additionalInstruction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "patientInstruction": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "timing": {
+            "$ref": "#/components/schemas/Timing"
+          },
+          "asNeededBoolean": {
+            "type": "boolean"
+          },
+          "asNeededCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "site": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "route": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "method": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "doseAndRate": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DosageDoseAndRate"
+            }
+          },
+          "maxDosePerPeriod": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "maxDosePerAdministration": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "maxDosePerLifetime": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/dosage.html"
+      },
+      "DosageDoseAndRate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "doseRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "doseQuantity": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "rateRatio": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "rateRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "rateQuantity": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          }
+        }
+      },
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "value": {
+            "type": "number"
+          },
+          "comparator": {
+            "pattern": "(<|<=|>=|>)",
+            "type": "string"
+          },
+          "unit": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/r4/datatypes.html#Duration"
+      },
+      "Encounter": {
+        "required": [
+          "class",
+          "resourceType",
+          "status",
+          "subject",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "planned",
+              "arrived",
+              "triaged",
+              "in-progress",
+              "onleave",
+              "finished",
+              "cancelled",
+              "entered-in-error",
+              "unknown"
+            ]
+          },
+          "statusHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StatusHistory"
+            }
+          },
+          "classHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClassHistory"
+            }
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "serviceType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "episodeOfCare": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "participant": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Participant"
+            }
+          },
+          "appointment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "length": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "reasonCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "reasonReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "diagnosis": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Diagnosis"
+            }
+          },
+          "account": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "hospitalization": {
+            "$ref": "#/components/schemas/Hospitalization"
+          },
+          "location": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Location"
+            }
+          },
+          "serviceProvider": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "partOf": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "class": {
+            "$ref": "#/components/schemas/Coding"
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-encounter.html",
+        "example": {
+          "resourceType": "Encounter",
+          "id": "I2-5WR43OIGY4625GCVOZTBYODWIEVVWLDDWEDSXUTTHZCTHKKBIDTQ0000",
+          "meta": {
+            "lastUpdated": "2021-12-01T00:00:00Z"
+          },
+          "status": "finished",
+          "type": [
+            {
+              "text": "inpatient"
+            }
+          ],
+          "serviceType": {
+            "text": "inpatient"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1017283148V813263",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "period": {
+            "start": "2021-11-29",
+            "end": "2021-12-01"
+          },
+          "reasonCode": [
+            {
+              "coding": [
+                {
+                  "system": "http://www.va.gov/Terminology/VistADefinedTerms/9000010-.07",
+                  "version": "9",
+                  "code": "780.4",
+                  "display": "DIZZINESS AND GIDDINESS"
+                }
+              ],
+              "text": "DIZZINESS AND GIDDINESS"
+            }
+          ],
+          "hospitalization": {
+            "dischargeDisposition": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/discharge-disposition",
+                  "code": "X",
+                  "display": "RETURN TO COMMUNITY-INDEPENDENT"
+                }
+              ],
+              "text": "RETURN TO COMMUNITY-INDEPENDENT"
+            }
+          },
+          "location": [
+            {
+              "location": {
+                "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location/I2-2FPCKUIXVR7RJLLG34XVWGZERM000000",
+                "display": "MENTAL HEALTH SERVICES"
+              }
+            }
+          ],
+          "serviceProvider": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-YCRI7L52BYQL63ZFALGWIWF2WU000000",
+            "display": "WASHINGTON VA MEDICAL CENTER"
+          },
+          "class": {
+            "display": "IMP"
+          }
+        }
+      },
+      "EncounterBundle": {
+        "type": "object",
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter?patient=1017283148V813263&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Encounter/I2-5WR43OIGY4625GCVOZTBYODWIEVVWLDDWEDSXUTTHZCTHKKBIDTQ0000",
+              "resource": {
+                "resourceType": "Encounter",
+                "id": "I2-5WR43OIGY4625GCVOZTBYODWIEVVWLDDWEDSXUTTHZCTHKKBIDTQ0000",
+                "meta": {
+                  "lastUpdated": "2021-12-01T00:00:00Z"
+                },
+                "status": "finished",
+                "type": [
+                  {
+                    "text": "inpatient"
+                  }
+                ],
+                "serviceType": {
+                  "text": "inpatient"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/1017283148V813263",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "period": {
+                  "start": "2021-11-29",
+                  "end": "2021-12-01"
+                },
+                "reasonCode": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/9000010-.07",
+                        "version": "9",
+                        "code": "780.4",
+                        "display": "DIZZINESS AND GIDDINESS"
+                      }
+                    ],
+                    "text": "DIZZINESS AND GIDDINESS"
+                  }
+                ],
+                "hospitalization": {
+                  "dischargeDisposition": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/discharge-disposition",
+                        "code": "X",
+                        "display": "RETURN TO COMMUNITY-INDEPENDENT"
+                      }
+                    ],
+                    "text": "RETURN TO COMMUNITY-INDEPENDENT"
+                  }
+                },
+                "location": [
+                  {
+                    "location": {
+                      "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location/I2-2FPCKUIXVR7RJLLG34XVWGZERM000000",
+                      "display": "MENTAL HEALTH SERVICES"
+                    }
+                  }
+                ],
+                "serviceProvider": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-YCRI7L52BYQL63ZFALGWIWF2WU000000",
+                  "display": "WASHINGTON VA MEDICAL CENTER"
+                },
+                "class": {
+                  "display": "IMP"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Expression": {
+        "required": [
+          "language"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "description": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "name": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "expression": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "reference": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#expression"
+      },
+      "Extension": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "valueBase64Binary": {
+            "pattern": "(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+",
+            "type": "string"
+          },
+          "valueBoolean": {
+            "type": "boolean"
+          },
+          "valueCanonical": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "valueCode": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "valueDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+            "type": "string"
+          },
+          "valueDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "valueDecimal": {
+            "type": "number"
+          },
+          "valueId": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "valueInstant": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "valueInteger": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "valueMarkdown": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "valueOid": {
+            "pattern": "urn:oid:[0-2](\\.(0|[1-9][0-9]*))+",
+            "type": "string"
+          },
+          "valuePositiveInt": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "valueString": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "valueTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          },
+          "valueUnsignedInt": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "valueUri": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "valueUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "valueUuid": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "valueAddress": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "valueAge": {
+            "$ref": "#/components/schemas/Age"
+          },
+          "valueAnnotation": {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          "valueAttachment": {
+            "$ref": "#/components/schemas/Attachment"
+          },
+          "valueCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueCoding": {
+            "$ref": "#/components/schemas/Coding"
+          },
+          "valueContactPoint": {
+            "$ref": "#/components/schemas/ContactPoint"
+          },
+          "valueCount": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueDistance": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueDuration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "valueHumanName": {
+            "$ref": "#/components/schemas/HumanName"
+          },
+          "valueIdentifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "valueMoney": {
+            "$ref": "#/components/schemas/Money"
+          },
+          "valuePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "valueQuantity": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "valueRatio": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "valueReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "valueSampledData": {
+            "$ref": "#/components/schemas/SampledData"
+          },
+          "valueSignature": {
+            "$ref": "#/components/schemas/Signature"
+          },
+          "valueTiming": {
+            "$ref": "#/components/schemas/Timing"
+          },
+          "valueContactDetail": {
+            "$ref": "#/components/schemas/ContactDetail"
+          },
+          "valueContributor": {
+            "$ref": "#/components/schemas/Contributor"
+          },
+          "valueDataRequirement": {
+            "$ref": "#/components/schemas/DataRequirement"
+          },
+          "valueExpression": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "valueParameterDefinition": {
+            "$ref": "#/components/schemas/ParameterDefinition"
+          },
+          "valueRelatedArtifact": {
+            "$ref": "#/components/schemas/RelatedArtifact"
+          },
+          "valueTriggerDefinition": {
+            "$ref": "#/components/schemas/TriggerDefinition"
+          },
+          "valueUsageContext": {
+            "$ref": "#/components/schemas/UsageContext"
+          },
+          "valueDosage": {
+            "$ref": "#/components/schemas/Dosage"
+          },
+          "valueMeta": {
+            "$ref": "#/components/schemas/Meta"
+          }
+        },
+        "description": "http://hl7.org/fhir/R4/extensibility.html#extension"
+      },
+      "FocalDevice": {
+        "required": [
+          "manipulated"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "action": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "manipulated": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "Hospitalization": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "preAdmissionIdentifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "admitSource": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "reAdmission": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "dietPreference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "specialCourtesy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "specialArrangement": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "destination": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "dischargeDisposition": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          }
+        }
+      },
+      "HoursOfOperation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "daysOfWeek": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "mon",
+                "tue",
+                "wed",
+                "thu",
+                "fri",
+                "sat",
+                "sun"
+              ]
+            }
+          },
+          "allDay": {
+            "type": "boolean"
+          },
+          "openingTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          },
+          "closingTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          }
+        }
+      },
+      "HumanName": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "use": {
+            "type": "string",
+            "enum": [
+              "usual",
+              "official",
+              "temp",
+              "nickname",
+              "anonymous",
+              "old",
+              "maiden"
+            ]
+          },
+          "text": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "family": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "given": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "prefix": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "suffix": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#HumanName"
+      },
+      "Identifier": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "use": {
+            "type": "string",
+            "enum": [
+              "usual",
+              "official",
+              "temp",
+              "secondary",
+              "old"
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "value": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "assigner": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Identifier"
+      },
+      "Immunization": {
+        "required": [
+          "patient",
+          "primarySource",
+          "resourceType",
+          "vaccineCode"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "entered-in-error",
+              "not-done"
+            ]
+          },
+          "_status": {
+            "$ref": "#/components/schemas/Extension"
+          },
+          "statusReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "vaccineCode": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "patient": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "occurrenceDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "occurrenceString": {
+            "type": "string"
+          },
+          "recorded": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "primarySource": {
+            "type": "boolean"
+          },
+          "reportOrigin": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "location": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "manufacturer": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "lotNumber": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+            "type": "string"
+          },
+          "site": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "route": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "doseQuantity": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "performer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImmunizationPerformer"
+            }
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "reasonCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "reasonReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "isSubpotent": {
+            "type": "boolean"
+          },
+          "subpotentReason": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "education": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImmunizationEducation"
+            }
+          },
+          "programEligibility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "fundingSource": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "reaction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImmunizationReaction"
+            }
+          },
+          "protocolApplied": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImmunizationProtocolApplied"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-immunization.html\n\n**Notes**\n\n`manufacturer.display` is populated based on CVX to Manufacturer mappings from the [CDC Product Name to CVX and MVX code set](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=tradename). In cases where a CVX code maps to multiple manufacturers, the exact manufacturer cannot be determined and thus `manufacturer.display` will be omitted from the response.",
+        "example": {
+          "resourceType": "Immunization",
+          "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+          "status": "completed",
+          "vaccineCode": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/sid/cvx",
+                "code": "114"
+              }
+            ],
+            "text": "meningococcal MCV4P"
+          },
+          "patient": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/2000163",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "occurrenceString": "2017-04-24T01:15:52Z",
+          "reaction": [
+            {
+              "detail": {
+                "display": "Lethargy"
+              }
+            }
+          ]
+        }
+      },
+      "ImmunizationBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImmunizationEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Immunization?patient=2000163&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Immunization?patient=2000163&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Immunization?patient=2000163&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Immunization/I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+              "resource": {
+                "resourceType": "Immunization",
+                "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+                "status": "completed",
+                "vaccineCode": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/sid/cvx",
+                      "code": "114"
+                    }
+                  ],
+                  "text": "meningococcal MCV4P"
+                },
+                "patient": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/2000163",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "occurrenceString": "2017-04-24T01:15:52Z",
+                "reaction": [
+                  {
+                    "detail": {
+                      "display": "Lethargy"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "ImmunizationEducation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "documentType": {
+            "type": "string"
+          },
+          "reference": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "publicationDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "presentationDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          }
+        }
+      },
+      "ImmunizationEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Immunization"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "ImmunizationPerformer": {
+        "required": [
+          "actor"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "function": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "ImmunizationProtocolApplied": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "series": {
+            "type": "string"
+          },
+          "authority": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "targetDisease": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "doseNumberPositiveInt": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "doseNumberString": {
+            "type": "string"
+          },
+          "seriesDosesPositiveInt": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesDosesString": {
+            "type": "string"
+          }
+        }
+      },
+      "ImmunizationReaction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "date": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "detail": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "reported": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Implementation": {
+        "required": [
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "description": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "custodian": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "Issue": {
+        "required": [
+          "code",
+          "severity"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "fatal",
+              "error",
+              "warning",
+              "information"
+            ]
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string",
+            "description": "https://www.hl7.org/fhir/R4/valueset-issue-type.html"
+          },
+          "details": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "diagnostics": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "location": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expression": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/operationoutcome-definitions.html#OperationOutcome.issue"
+      },
+      "Link": {
+        "required": [
+          "other",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "other": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "replaced-by",
+              "replaces",
+              "refer",
+              "seealso"
+            ]
+          }
+        }
+      },
+      "Location": {
+        "required": [
+          "name",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "suspended",
+              "inactive"
+            ]
+          },
+          "operationalStatus": {
+            "$ref": "#/components/schemas/Coding"
+          },
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "instance",
+              "kind"
+            ]
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "physicalType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "position": {
+            "$ref": "#/components/schemas/Position"
+          },
+          "managingOrganization": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "partOf": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "hoursOfOperation": {
+            "$ref": "#/components/schemas/HoursOfOperation"
+          },
+          "availabilityExceptions": {
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-location.html",
+        "example": {
+          "resourceType": "Location",
+          "id": "I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000",
+          "status": "active",
+          "name": "VISUAL IMPAIRMENT SVCS OUTPATIENT REHAB (VISOR)",
+          "description": "VISUAL IMPAIRMENT SVCS OUTPATIENT REHAB (VISOR)",
+          "mode": "instance",
+          "type": [
+            {
+              "coding": [
+                {
+                  "display": "OUTPATIENT CLINIC"
+                }
+              ],
+              "text": "OUTPATIENT CLINIC"
+            }
+          ],
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "908-647-0180 EXT 4437"
+            }
+          ],
+          "address": {
+            "text": "151 KNOLLCROFT ROAD LYONS NJ 07939",
+            "line": [
+              "151 KNOLLCROFT ROAD"
+            ],
+            "city": "LYONS",
+            "state": "NJ",
+            "postalCode": "07939"
+          },
+          "physicalType": {
+            "coding": [
+              {
+                "display": "BUILDING 7"
+              }
+            ],
+            "text": "BUILDING 7"
+          },
+          "managingOrganization": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-TYIC2AW2NXNADER4SKRKJQZWRE000000",
+            "display": "LYONS VA MEDICAL CENTER"
+          }
+        }
+      },
+      "LocationBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocationEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location?_id=I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location?_id=I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location?_id=I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Location/I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000",
+              "resource": {
+                "resourceType": "Location",
+                "id": "I2-4KG3N5YUSPTWD3DAFMLMRL5V5U000000",
+                "status": "active",
+                "name": "VISUAL IMPAIRMENT SVCS OUTPATIENT REHAB (VISOR)",
+                "description": "VISUAL IMPAIRMENT SVCS OUTPATIENT REHAB (VISOR)",
+                "mode": "instance",
+                "type": [
+                  {
+                    "coding": [
+                      {
+                        "display": "OUTPATIENT CLINIC"
+                      }
+                    ],
+                    "text": "OUTPATIENT CLINIC"
+                  }
+                ],
+                "telecom": [
+                  {
+                    "system": "phone",
+                    "value": "908-647-0180 EXT 4437"
+                  }
+                ],
+                "address": {
+                  "text": "151 KNOLLCROFT ROAD LYONS NJ 07939",
+                  "line": [
+                    "151 KNOLLCROFT ROAD"
+                  ],
+                  "city": "LYONS",
+                  "state": "NJ",
+                  "postalCode": "07939"
+                },
+                "physicalType": {
+                  "coding": [
+                    {
+                      "display": "BUILDING 7"
+                    }
+                  ],
+                  "text": "BUILDING 7"
+                },
+                "managingOrganization": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-TYIC2AW2NXNADER4SKRKJQZWRE000000",
+                  "display": "LYONS VA MEDICAL CENTER"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "LocationEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Location"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "Medication": {
+        "required": [
+          "code",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive",
+              "entered-in-error"
+            ]
+          },
+          "manufacturer": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "form": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "amount": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "ingredient": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicationIngredient"
+            }
+          },
+          "batch": {
+            "$ref": "#/components/schemas/MedicationBatch"
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-medication.html",
+        "example": {
+          "resourceType": "Medication",
+          "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+          "code": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/sid/ndc",
+                "code": "2501-813-16"
+              }
+            ],
+            "text": "Timoptic 5mg/ml solution"
+          },
+          "status": "active",
+          "manufacturer": {
+            "id": "org5",
+            "display": "Aton Pharma Inc"
+          },
+          "form": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "75359005"
+              }
+            ],
+            "text": "Opthalmic Solution"
+          },
+          "ingredient": [
+            {
+              "itemCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "75359005"
+                  }
+                ],
+                "text": "Timolol Maleate (substance)"
+              }
+            }
+          ],
+          "batch": {
+            "lotNumber": "9494788",
+            "expirationDate": "2017-05-22"
+          }
+        }
+      },
+      "MedicationBatch": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "lotNumber": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          }
+        }
+      },
+      "MedicationBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicationEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication?_id=I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication?_id=I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication?_id=I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+              "resource": {
+                "resourceType": "Medication",
+                "id": "I2-U4FPJS3E633MAJQBCAA2KAB5BQ000000",
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/sid/ndc",
+                      "code": "2501-813-16"
+                    }
+                  ],
+                  "text": "Timoptic 5mg/ml solution"
+                },
+                "status": "active",
+                "manufacturer": {
+                  "id": "org5",
+                  "display": "Aton Pharma Inc"
+                },
+                "form": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "75359005"
+                    }
+                  ],
+                  "text": "Opthalmic Solution"
+                },
+                "ingredient": [
+                  {
+                    "itemCodeableConcept": {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "75359005"
+                        }
+                      ],
+                      "text": "Timolol Maleate (substance)"
+                    }
+                  }
+                ],
+                "batch": {
+                  "lotNumber": "9494788",
+                  "expirationDate": "2017-05-22"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "MedicationEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Medication"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "MedicationIngredient": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "itemCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "itemReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "strength": {
+            "$ref": "#/components/schemas/Ratio"
+          }
+        }
+      },
+      "MedicationRequest": {
+        "required": [
+          "authoredOn",
+          "intent",
+          "resourceType",
+          "status",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "on-hold",
+              "cancelled",
+              "completed",
+              "entered-in-error",
+              "stopped",
+              "draft",
+              "unknown"
+            ]
+          },
+          "statusReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "intent": {
+            "type": "string",
+            "enum": [
+              "proposal",
+              "plan",
+              "order",
+              "original-order",
+              "reflex-order",
+              "filler-order",
+              "instance-order",
+              "option"
+            ]
+          },
+          "category": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "routine",
+              "urgent",
+              "asap",
+              "stat"
+            ]
+          },
+          "doNotPerform": {
+            "type": "boolean"
+          },
+          "reportedBoolean": {
+            "type": "boolean"
+          },
+          "reportedReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "medicationCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "medicationReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "supportingInformation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "authoredOn": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "requester": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "_requester": {
+            "$ref": "#/components/schemas/Extension"
+          },
+          "performer": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "performerType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "recorder": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "reasonCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "reasonReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "instantiatesCanonical": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "instantiatesUri": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "groupIdentifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "courseOfTherapyType": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "insurance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "dosageInstruction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Dosage"
+            }
+          },
+          "dispenseRequest": {
+            "$ref": "#/components/schemas/MedicationRequestDispenseRequest"
+          },
+          "substitution": {
+            "$ref": "#/components/schemas/MedicationRequestSubstitution"
+          },
+          "priorPrescription": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "detectedIssue": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "eventHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-medicationrequest.html",
+        "example": {
+          "resourceType": "MedicationRequest",
+          "id": "medrx0302",
+          "status": "active",
+          "intent": "order",
+          "medicationReference": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-LTU3MVTE2VLWXUQKKCRRTEWJDE000000",
+            "display": "Azithromycin 250mg capsule"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/32000225",
+            "display": "Mrs. Sheba703 Harris789"
+          },
+          "authoredOn": "2015-01-15T12:03:52Z",
+          "_requester": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/extension-data-absent-reason.html",
+                "valueCode": "unknown"
+              }
+            ]
+          },
+          "reasonCode": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "11840006",
+                  "display": "Traveler's diarrhea"
+                }
+              ],
+              "text": "Traveller's Diarrhea (disorder)"
+            }
+          ],
+          "note": [
+            {
+              "authorString": "Patient told to take with food"
+            }
+          ],
+          "dosageInstruction": [
+            {
+              "text": "Once per day.",
+              "timing": {
+                "code": {
+                  "text": "As directed by physician."
+                }
+              },
+              "route": {
+                "text": "As directed by physician."
+              }
+            }
+          ],
+          "substitution": {
+            "allowedBoolean": true,
+            "reason": {
+              "text": "formulary policy"
+            }
+          }
+        }
+      },
+      "MedicationRequestBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MedicationRequestEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=32000225&intent=order&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=32000225&intent=order&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest?patient=32000225&intent=order&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/MedicationRequest/I2-AOV4FXGQLPIXGZPTMTWY7Y7KJ4000000",
+              "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "medrx0302",
+                "status": "active",
+                "intent": "order",
+                "medicationReference": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Medication/I2-LTU3MVTE2VLWXUQKKCRRTEWJDE000000",
+                  "display": "Azithromycin 250mg capsule"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient/32000225",
+                  "display": "Mrs. Sheba703 Harris789"
+                },
+                "authoredOn": "2015-01-15T12:03:52Z",
+                "_requester": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/extension-data-absent-reason.html",
+                      "valueCode": "unknown"
+                    }
+                  ]
+                },
+                "reasonCode": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://snomed.info/sct",
+                        "code": "11840006",
+                        "display": "Traveler's diarrhea"
+                      }
+                    ],
+                    "text": "Traveller's Diarrhea (disorder)"
+                  }
+                ],
+                "note": [
+                  {
+                    "authorString": "Patient told to take with food"
+                  }
+                ],
+                "dosageInstruction": [
+                  {
+                    "text": "Once per day.",
+                    "timing": {
+                      "code": {
+                        "text": "As directed by physician."
+                      }
+                    },
+                    "route": {
+                      "text": "As directed by physician."
+                    }
+                  }
+                ],
+                "substitution": {
+                  "allowedBoolean": true,
+                  "reason": {
+                    "text": "formulary policy"
+                  }
+                }
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "MedicationRequestDispenseRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "initialFill": {
+            "$ref": "#/components/schemas/MedicationRequestDispenseRequestInitialFill"
+          },
+          "dispenseInterval": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "validityPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "numberOfRepeatsAllowed": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "quantity": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "expectedSupplyDuration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "performer": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "MedicationRequestDispenseRequestInitialFill": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "quantity": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "duration": {
+            "$ref": "#/components/schemas/Duration"
+          }
+        }
+      },
+      "MedicationRequestEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/MedicationRequest"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "MedicationRequestSubstitution": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "allowedBoolean": {
+            "type": "boolean"
+          },
+          "allowedCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          }
+        }
+      },
+      "Messaging": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "endpoint": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessagingEndpoint"
+            }
+          },
+          "reliableCache": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "supportedMessage": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupportedMessage"
+            }
+          }
+        }
+      },
+      "MessagingEndpoint": {
+        "required": [
+          "address",
+          "protocol"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/Coding"
+          },
+          "address": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        }
+      },
+      "Meta": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "versionId": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "lastUpdated": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "source": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "profile": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "security": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Coding"
+            }
+          },
+          "tag": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Coding"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/resource.html#meta"
+      },
+      "Money": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "value": {
+            "type": "number"
+          },
+          "currency": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Money"
+      },
+      "Narrative": {
+        "required": [
+          "div",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "generated",
+              "extensions",
+              "additional",
+              "empty"
+            ]
+          },
+          "div": {
+            "pattern": "<.+>",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/narrative.html"
+      },
+      "Observation": {
+        "required": [
+          "category",
+          "code",
+          "resourceType",
+          "status",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "partOf": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "registered",
+              "preliminary",
+              "final",
+              "amended",
+              "corrected",
+              "cancelled",
+              "entered-in-error",
+              "unknown"
+            ]
+          },
+          "category": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "focus": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "effectiveDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "effectivePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "issued": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "performer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "valueQuantity": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueString": {
+            "type": "string"
+          },
+          "valueBoolean": {
+            "type": "boolean"
+          },
+          "valueInteger": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "valueRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "valueRatio": {
+            "$ref": "#/components/schemas/Ratio"
+          },
+          "valueSampledData": {
+            "$ref": "#/components/schemas/SampledData"
+          },
+          "valueTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          },
+          "valueDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "valuePeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "dataAbsentReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "interpretation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "bodySite": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "method": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "specimen": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "device": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "referenceRange": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReferenceRange"
+            }
+          },
+          "hasMember": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "derivedFrom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "component": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Component"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-observation-lab.html",
+        "example": {
+          "resourceType": "Observation",
+          "id": "I2-RRCTYID4OWJHGGFQ7S7YPH4G6XVBG6D7VORRKERYLTZD7VBQLCJQ0000",
+          "status": "final",
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "laboratory",
+                  "display": "Laboratory"
+                }
+              ],
+              "text": "Laboratory"
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "32623-1",
+                "display": "Platelet mean volume [Entitic volume] in Blood by"
+              }
+            ],
+            "text": "Platelet mean volume [Entitic volume] in Blood by"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/argonaut/v0/Patient/1017283148V813263",
+            "display": "Mr. Aurelio227 Cruickshank494"
+          },
+          "effectiveDateTime": "2017-04-24T01:15:52Z",
+          "issued": "2017-04-24T01:15:52Z",
+          "valueQuantity": {
+            "value": 10.226877417360429,
+            "unit": "fL",
+            "system": "http://unitsofmeasure.org",
+            "code": "fL"
+          }
+        }
+      },
+      "ObservationBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObservationEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/argonaut/v0/Observation?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/argonaut/v0/Observation?patient=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/argonaut/v0/Observation?patient=1017283148V813263&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/argonaut/v0/Observation/I2-RRCTYID4OWJHGGFQ7S7YPH4G6XVBG6D7VORRKERYLTZD7VBQLCJQ0000",
+              "resource": {
+                "resourceType": "Observation",
+                "id": "I2-RRCTYID4OWJHGGFQ7S7YPH4G6XVBG6D7VORRKERYLTZD7VBQLCJQ0000",
+                "status": "final",
+                "category": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                        "code": "laboratory",
+                        "display": "Laboratory"
+                      }
+                    ],
+                    "text": "Laboratory"
+                  }
+                ],
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "32623-1",
+                      "display": "Platelet mean volume [Entitic volume] in Blood by"
+                    }
+                  ],
+                  "text": "Platelet mean volume [Entitic volume] in Blood by"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/argonaut/v0/Patient/1017283148V813263",
+                  "display": "Mr. Aurelio227 Cruickshank494"
+                },
+                "effectiveDateTime": "2017-04-24T01:15:52Z",
+                "issued": "2017-04-24T01:15:52Z",
+                "valueQuantity": {
+                  "value": 10.226877417360429,
+                  "unit": "fL",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "fL"
+                }
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "ObservationEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Observation"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "Operation": {
+        "required": [
+          "definition",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "definition": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        }
+      },
+      "OperationOutcome": {
+        "required": [
+          "issue",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "issue": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Issue"
+            }
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/operationoutcome.html",
+        "example": {
+          "resourceType": "OperationOutcome",
+          "issue": [
+            {
+              "severity": "error",
+              "code": "request error",
+              "details": {
+                "text": "This request can not be processed"
+              }
+            }
+          ]
+        }
+      },
+      "Organization": {
+        "required": [
+          "active",
+          "name",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          },
+          "partOf": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationContact"
+            }
+          },
+          "endpoint": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        },
+        "description": "http://hl7.org/fhir/us/carin-bb/2020Feb/StructureDefinition-CARIN-BB-Organization.html",
+        "example": {
+          "resourceType": "Organization",
+          "id": "I2-ZJURFG76GQN5LW7WP56TXADUFM000000",
+          "identifier": [
+            {
+              "system": "http://hl7.org/fhir/sid/us-npi",
+              "value": "1205983228"
+            }
+          ],
+          "active": true,
+          "name": "NEW AMSTERDAM CBOC",
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "800 555-7710"
+            },
+            {
+              "system": "phone",
+              "value": "800 555-7710"
+            }
+          ],
+          "address": [
+            {
+              "text": "10 MONROE AVE, SUITE 6B PO BOX 4160 NEW AMSTERDAM OH 44444-4160",
+              "line": [
+                "10 MONROE AVE, SUITE 6B",
+                "PO BOX 4160"
+              ],
+              "city": "NEW AMSTERDAM",
+              "state": "OH",
+              "postalCode": "44444-4160"
+            }
+          ]
+        }
+      },
+      "OrganizationBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrganizationEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization?_id=I2-ZJURFG76GQN5LW7WP56TXADUFM000000&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization?_id=I2-ZJURFG76GQN5LW7WP56TXADUFM000000&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization?_id=I2-ZJURFG76GQN5LW7WP56TXADUFM000000&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-ZJURFG76GQN5LW7WP56TXADUFM000000",
+              "resource": {
+                "resourceType": "Organization",
+                "id": "I2-ZJURFG76GQN5LW7WP56TXADUFM000000",
+                "identifier": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/us-npi",
+                    "value": "1205983228"
+                  }
+                ],
+                "active": true,
+                "name": "NEW AMSTERDAM CBOC",
+                "telecom": [
+                  {
+                    "system": "phone",
+                    "value": "800 555-7710"
+                  },
+                  {
+                    "system": "phone",
+                    "value": "800 555-7710"
+                  }
+                ],
+                "address": [
+                  {
+                    "text": "10 MONROE AVE, SUITE 6B PO BOX 4160 NEW AMSTERDAM OH 44444-4160",
+                    "line": [
+                      "10 MONROE AVE, SUITE 6B",
+                      "PO BOX 4160"
+                    ],
+                    "city": "NEW AMSTERDAM",
+                    "state": "OH",
+                    "postalCode": "44444-4160"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "OrganizationContact": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "purpose": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "name": {
+            "$ref": "#/components/schemas/HumanName"
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          }
+        }
+      },
+      "OrganizationEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "ParameterDefinition": {
+        "required": [
+          "type",
+          "use"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "use": {
+            "type": "string",
+            "enum": [
+              "in",
+              "out"
+            ]
+          },
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "documentation": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "type": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "profile": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#parameterdefinition"
+      },
+      "Participant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "individual": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "Patient": {
+        "required": [
+          "gender",
+          "name",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HumanName"
+            }
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "gender": {
+            "type": "string",
+            "enum": [
+              "male",
+              "female",
+              "other",
+              "unknown"
+            ]
+          },
+          "birthDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+            "type": "string"
+          },
+          "deceasedBoolean": {
+            "type": "boolean"
+          },
+          "deceasedDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          },
+          "maritalStatus": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "multipleBirthBoolean": {
+            "type": "boolean"
+          },
+          "multipleBirthInteger": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "photo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Attachment"
+            }
+          },
+          "contact": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PatientContact"
+            }
+          },
+          "communication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Communication"
+            }
+          },
+          "generalPractitioner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "managingOrganization": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-patient.html",
+        "example": {
+          "resourceType": "Patient",
+          "id": "2000163",
+          "extension": [
+            {
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "https://www.hl7.org/fhir/us/core/CodeSystem-cdcrec.html",
+                    "code": "2016-3",
+                    "display": "White"
+                  }
+                },
+                {
+                  "url": "text",
+                  "valueString": "White"
+                }
+              ],
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+            },
+            {
+              "extension": [
+                {
+                  "url": "ombCategory",
+                  "valueCoding": {
+                    "system": "https://www.hl7.org/fhir/us/core/CodeSystem-cdcrec.html",
+                    "code": "2186-5",
+                    "display": "Not Hispanic or Latino"
+                  }
+                },
+                {
+                  "url": "text",
+                  "valueString": "Not Hispanic or Latino"
+                }
+              ],
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+              "valueCode": "M"
+            }
+          ],
+          "identifier": [
+            {
+              "use": "usual",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/v2/0203",
+                    "code": "MR"
+                  }
+                ]
+              },
+              "system": "http://va.gov/mpi",
+              "value": "2000163"
+            },
+            {
+              "use": "official",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/v2/0203",
+                    "code": "SB"
+                  }
+                ]
+              },
+              "system": "http://hl7.org/fhir/sid/us-ssn",
+              "value": "999-61-4803"
+            }
+          ],
+          "name": [
+            {
+              "use": "usual",
+              "text": "Mr. Aurelio227 Cruickshank494",
+              "family": "Cruickshank494",
+              "given": [
+                "Aurelio227"
+              ]
+            }
+          ],
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "5555191065",
+              "use": "mobile"
+            },
+            {
+              "system": "email",
+              "value": "Aurelio227.Cruickshank494@email.example"
+            }
+          ],
+          "gender": "male",
+          "birthDate": "1995-02-06",
+          "deceasedBoolean": false,
+          "address": [
+            {
+              "line": [
+                "909 Rohan Highlands"
+              ],
+              "city": "Mesa",
+              "state": "Arizona",
+              "postalCode": "85120"
+            }
+          ],
+          "maritalStatus": {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/R4/v3/NullFlavor/cs.html",
+                "code": "UNK",
+                "display": "unknown"
+              }
+            ],
+            "text": "unknown"
+          }
+        }
+      },
+      "PatientBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PatientEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient?identifier=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient?identifier=1017283148V813263&page=1&_count=15"
+            },
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Patient?identifer=1017283148V813263&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "resource": {
+                "resourceType": "Patient",
+                "id": "2000163",
+                "extension": [
+                  {
+                    "extension": [
+                      {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                          "system": "https://www.hl7.org/fhir/us/core/CodeSystem-cdcrec.html",
+                          "code": "2016-3",
+                          "display": "White"
+                        }
+                      },
+                      {
+                        "url": "text",
+                        "valueString": "White"
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                  },
+                  {
+                    "extension": [
+                      {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                          "system": "https://www.hl7.org/fhir/us/core/CodeSystem-cdcrec.html",
+                          "code": "2186-5",
+                          "display": "Not Hispanic or Latino"
+                        }
+                      },
+                      {
+                        "url": "text",
+                        "valueString": "Not Hispanic or Latino"
+                      }
+                    ],
+                    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                    "valueCode": "M"
+                  }
+                ],
+                "identifier": [
+                  {
+                    "use": "usual",
+                    "type": {
+                      "coding": [
+                        {
+                          "system": "http://hl7.org/fhir/v2/0203",
+                          "code": "MR"
+                        }
+                      ]
+                    },
+                    "system": "http://va.gov/mpi",
+                    "value": "2000163"
+                  },
+                  {
+                    "use": "official",
+                    "type": {
+                      "coding": [
+                        {
+                          "system": "http://hl7.org/fhir/v2/0203",
+                          "code": "SB"
+                        }
+                      ]
+                    },
+                    "system": "http://hl7.org/fhir/sid/us-ssn",
+                    "value": "999-61-4803"
+                  }
+                ],
+                "name": [
+                  {
+                    "use": "usual",
+                    "text": "Mr. Aurelio227 Cruickshank494",
+                    "family": "Cruickshank494",
+                    "given": [
+                      "Aurelio227"
+                    ]
+                  }
+                ],
+                "telecom": [
+                  {
+                    "system": "phone",
+                    "value": "5555191065",
+                    "use": "mobile"
+                  },
+                  {
+                    "system": "email",
+                    "value": "Aurelio227.Cruickshank494@email.example"
+                  }
+                ],
+                "gender": "male",
+                "birthDate": "1995-02-06",
+                "deceasedBoolean": false,
+                "address": [
+                  {
+                    "line": [
+                      "909 Rohan Highlands"
+                    ],
+                    "city": "Mesa",
+                    "state": "Arizona",
+                    "postalCode": "85120"
+                  }
+                ],
+                "maritalStatus": {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/R4/v3/NullFlavor/cs.html",
+                      "code": "UNK",
+                      "display": "unknown"
+                    }
+                  ],
+                  "text": "unknown"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "PatientContact": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "relationship": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "name": {
+            "$ref": "#/components/schemas/HumanName"
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "gender": {
+            "type": "string",
+            "enum": [
+              "male",
+              "female",
+              "other",
+              "unknown"
+            ]
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        }
+      },
+      "PatientEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Patient"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "Performer": {
+        "required": [
+          "actor"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "function": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "onBehalfOf": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "Period": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "start": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "end": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Period"
+      },
+      "Position": {
+        "required": [
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "longitude": {
+            "type": "number"
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "altitude": {
+            "type": "number"
+          }
+        }
+      },
+      "Practitioner": {
+        "required": [
+          "identifier",
+          "name",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HumanName"
+            }
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          },
+          "gender": {
+            "type": "string",
+            "enum": [
+              "male",
+              "female",
+              "other",
+              "unknown"
+            ]
+          },
+          "birthDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+            "type": "string"
+          },
+          "photo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Attachment"
+            }
+          },
+          "qualification": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PractitionerQualification"
+            }
+          },
+          "communication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          }
+        },
+        "description": "http://hl7.org/fhir/us/core/StructureDefinition-us-core-practitioner.html",
+        "example": {
+          "resourceType": "Practitioner",
+          "id": "I2-HRJI2MVST2IQSPR7U5SACWIWZA000000",
+          "identifier": [
+            {
+              "system": "http://hl7.org/fhir/sid/us-npi",
+              "value": "1932127842"
+            }
+          ],
+          "active": true,
+          "name": [
+            {
+              "family": "DOE922",
+              "given": [
+                "JANE460"
+              ],
+              "prefix": [
+                "DR."
+              ],
+              "suffix": [
+                "MD"
+              ]
+            }
+          ],
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "555-555-1137",
+              "use": "work"
+            },
+            {
+              "system": "phone",
+              "value": "555-4055",
+              "use": "home"
+            },
+            {
+              "system": "pager",
+              "value": "5-541",
+              "use": "mobile"
+            }
+          ],
+          "address": [
+            {
+              "line": [
+                "555 E 5TH ST",
+                "SUITE B"
+              ],
+              "city": "CHEYENNE",
+              "state": "WYOMING",
+              "postalCode": "82001"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1964-02-23"
+        }
+      },
+      "PractitionerAvailableTime": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "daysOfWeek": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "mon",
+                "tue",
+                "wed",
+                "thu",
+                "fri",
+                "sat",
+                "sun"
+              ]
+            }
+          },
+          "allDay": {
+            "type": "boolean"
+          },
+          "availableStartTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          },
+          "availableEndTime": {
+            "pattern": "([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?",
+            "type": "string"
+          }
+        }
+      },
+      "PractitionerBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PractitionerEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner?identifier=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Fus-npi%7C1932127842&_count=30&page=1"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner?identifier=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Fus-npi%7C1932127842&_count=30&page=1"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner?identifier=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Fus-npi%7C1932127842&_count=30&page=1"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-HRJI2MVST2IQSPR7U5SACWIWZA000000",
+              "resource": {
+                "resourceType": "Practitioner",
+                "id": "I2-HRJI2MVST2IQSPR7U5SACWIWZA000000",
+                "identifier": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/us-npi",
+                    "value": "1932127842"
+                  }
+                ],
+                "active": true,
+                "name": [
+                  {
+                    "family": "DOE922",
+                    "given": [
+                      "JANE460"
+                    ],
+                    "prefix": [
+                      "DR."
+                    ],
+                    "suffix": [
+                      "MD"
+                    ]
+                  }
+                ],
+                "telecom": [
+                  {
+                    "system": "phone",
+                    "value": "555-555-1137",
+                    "use": "work"
+                  },
+                  {
+                    "system": "phone",
+                    "value": "555-4055",
+                    "use": "home"
+                  },
+                  {
+                    "system": "pager",
+                    "value": "5-541",
+                    "use": "mobile"
+                  }
+                ],
+                "address": [
+                  {
+                    "line": [
+                      "555 E 5TH ST",
+                      "SUITE B"
+                    ],
+                    "city": "CHEYENNE",
+                    "state": "WYOMING",
+                    "postalCode": "82001"
+                  }
+                ],
+                "gender": "female",
+                "birthDate": "1964-02-23"
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "PractitionerEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Practitioner"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "PractitionerNotAvailable": {
+        "required": [
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "during": {
+            "$ref": "#/components/schemas/Period"
+          }
+        }
+      },
+      "PractitionerQualification": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "issuer": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        }
+      },
+      "PractitionerRole": {
+        "required": [
+          "organization",
+          "practitioner",
+          "resourceType"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "practitioner": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "code": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "specialty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "location": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "healthcareService": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "telecom": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactPoint"
+            }
+          },
+          "availableTime": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PractitionerAvailableTime"
+            }
+          },
+          "notAvailable": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PractitionerNotAvailable"
+            }
+          },
+          "availabilityExceptions": {
+            "type": "string"
+          },
+          "endpoint": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-practitionerrole.html",
+        "example": {
+          "resourceType": "PractitionerRole",
+          "id": "I2-3NOHFSBEAZEKYRMDWVWB7LAFJNCKM3SFLR2CYELHDC7DZ5X3BKGA0000",
+          "active": true,
+          "practitioner": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-54WJZ6YHNQICAV4YZRI54BVVCA000000",
+            "display": "Dr John248 Smith811, MD"
+          },
+          "organization": {
+            "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-TQFMJ6CCI4V425PUMWP2GRESZM000000",
+            "display": "LYONS VA MEDICAL CENTER"
+          },
+          "code": [
+            {
+              "coding": [
+                {
+                  "system": "http://nucc.org/provider-taxonomy",
+                  "code": "15",
+                  "display": "OPTOMETRIST"
+                }
+              ],
+              "text": "OPTOMETRIST"
+            }
+          ],
+          "specialty": [
+            {
+              "coding": [
+                {
+                  "system": "http://nucc.org/provider-taxonomy",
+                  "code": "207Q00000X",
+                  "display": "Family Medicine"
+                }
+              ],
+              "text": "Family Medicine"
+            }
+          ],
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "333-333-3333"
+            }
+          ],
+          "availableTime": [
+            {
+              "daysOfWeek": [
+                "mon",
+                "wed",
+                "fri"
+              ],
+              "availableStartTime": "08:00:00",
+              "availableEndTime": "15:00:00"
+            }
+          ]
+        }
+      },
+      "PractitionerRoleBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PractitionerRoleEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/PractitionerRole?practitioner.identifier=I2-54WJZ6YHNQICAV4YZRI54BVVCA000000&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/PractitionerRole?practitioner.identifier=I2-54WJZ6YHNQICAV4YZRI54BVVCA000000&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/fhir/v0/r4/PractitionerRole?practitioner.identifier=I2-54WJZ6YHNQICAV4YZRI54BVVCA000000&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/PractitionerRole/I2-3NOHFSBEAZEKYRMDWVWB7LAFJNCKM3SFLR2CYELHDC7DZ5X3BKGA0000",
+              "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "I2-3NOHFSBEAZEKYRMDWVWB7LAFJNCKM3SFLR2CYELHDC7DZ5X3BKGA0000",
+                "active": true,
+                "practitioner": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Practitioner/I2-54WJZ6YHNQICAV4YZRI54BVVCA000000",
+                  "display": "Dr John248 Smith811, MD"
+                },
+                "organization": {
+                  "reference": "https://sandbox-api.va.gov/services/fhir/v0/r4/Organization/I2-TQFMJ6CCI4V425PUMWP2GRESZM000000",
+                  "display": "LYONS VA MEDICAL CENTER"
+                },
+                "code": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://nucc.org/provider-taxonomy",
+                        "code": "15",
+                        "display": "OPTOMETRIST"
+                      }
+                    ],
+                    "text": "OPTOMETRIST"
+                  }
+                ],
+                "specialty": [
+                  {
+                    "coding": [
+                      {
+                        "system": "http://nucc.org/provider-taxonomy",
+                        "code": "207Q00000X",
+                        "display": "Family Medicine"
+                      }
+                    ],
+                    "text": "Family Medicine"
+                  }
+                ],
+                "telecom": [
+                  {
+                    "system": "phone",
+                    "value": "333-333-3333"
+                  }
+                ],
+                "availableTime": [
+                  {
+                    "daysOfWeek": [
+                      "mon",
+                      "wed",
+                      "fri"
+                    ],
+                    "availableStartTime": "08:00:00",
+                    "availableEndTime": "15:00:00"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "PractitionerRoleEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/PractitionerRole"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "Procedure": {
+        "required": [
+          "code",
+          "resourceType",
+          "status",
+          "subject"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "text": {
+            "$ref": "#/components/schemas/Narrative"
+          },
+          "contained": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "identifier": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Identifier"
+            }
+          },
+          "instantiatesCanonical": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "instantiatesUri": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "basedOn": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "partOf": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "preparation",
+              "in-progress",
+              "not-done",
+              "on-hold",
+              "stopped",
+              "completed",
+              "entered-in-error",
+              "unknown"
+            ]
+          },
+          "statusReason": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "category": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "encounter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "performedDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "performedPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "recorder": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "asserter": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "performer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Performer"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "reasonCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "reasonReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "bodySite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "report": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "complication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "complicationDetail": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "followUp": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "note": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            }
+          },
+          "focalDevice": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FocalDevice"
+            }
+          },
+          "usedReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Reference"
+            }
+          },
+          "usedCode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          }
+        },
+        "description": "https://hl7.org/fhir/us/core/STU4/StructureDefinition-us-core-procedure.html",
+        "example": {
+          "resourceType": "Procedure",
+          "id": "I2-AOV4FXGQLPIXGZPTMTWY7Y7KJ4000000",
+          "status": "completed",
+          "code": {
+            "coding": [
+              {
+                "system": "http://www.ama-assn.org/go/cpt",
+                "code": "XXXXX",
+                "display": "Renal dialysis (procedure)"
+              }
+            ],
+            "text": "Renal dialysis (procedure)"
+          },
+          "subject": {
+            "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/32000225",
+            "display": "Mrs. Sheba703 Harris789"
+          },
+          "performedDateTime": "1996-06-25T02:42:52Z",
+          "location": {
+            "reference": "https://sandbox-api.va.gov/services/r4/v0/Location/I2-C4YZL2HYFARY5F75TSUENODC6U000000",
+            "display": "Behavioral Health Facility"
+          }
+        }
+      },
+      "ProcedureBundle": {
+        "required": [
+          "resourceType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "resourceType": {
+            "type": "string"
+          },
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "implicitRules": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "language": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "document",
+              "message",
+              "transaction",
+              "transaction-response",
+              "batch",
+              "batch-response",
+              "history",
+              "searchset",
+              "collection"
+            ]
+          },
+          "timestamp": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "entry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcedureEntry"
+            }
+          },
+          "signature": {
+            "$ref": "#/components/schemas/Signature"
+          }
+        },
+        "example": {
+          "resourceType": "Bundle",
+          "type": "searchset",
+          "total": 1,
+          "link": [
+            {
+              "relation": "self",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Procedure?patient=32000225&page=1&_count=15"
+            },
+            {
+              "relation": "first",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Procedure?patient=32000225&page=1&_count=15"
+            },
+            {
+              "relation": "last",
+              "url": "https://sandbox-api.va.gov/services/r4/v0/Procedure?patient=32000225&page=1&_count=15"
+            }
+          ],
+          "entry": [
+            {
+              "fullUrl": "https://sandbox-api.va.gov/services/r4/v0/Procedure/I2-AOV4FXGQLPIXGZPTMTWY7Y7KJ4000000",
+              "resource": {
+                "resourceType": "Procedure",
+                "id": "I2-AOV4FXGQLPIXGZPTMTWY7Y7KJ4000000",
+                "status": "completed",
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://www.ama-assn.org/go/cpt",
+                      "code": "XXXXX",
+                      "display": "Renal dialysis (procedure)"
+                    }
+                  ],
+                  "text": "Renal dialysis (procedure)"
+                },
+                "subject": {
+                  "reference": "https://sandbox-api.va.gov/services/r4/v0/Patient/32000225",
+                  "display": "Mrs. Sheba703 Harris789"
+                },
+                "performedDateTime": "1996-06-25T02:42:52Z",
+                "location": {
+                  "reference": "https://sandbox-api.va.gov/services/r4/v0/Location/I2-C4YZL2HYFARY5F75TSUENODC6U000000",
+                  "display": "Behavioral Health Facility"
+                }
+              },
+              "search": {
+                "mode": "match"
+              }
+            }
+          ]
+        }
+      },
+      "ProcedureEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "link": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleLink"
+            }
+          },
+          "fullUrl": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/Procedure"
+          },
+          "search": {
+            "$ref": "#/components/schemas/Search"
+          },
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "response": {
+            "$ref": "#/components/schemas/Response"
+          }
+        }
+      },
+      "Quantity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "value": {
+            "type": "number"
+          },
+          "comparator": {
+            "pattern": "(<|<=|>=|>)",
+            "type": "string"
+          },
+          "unit": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Quantity"
+      },
+      "Range": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "low": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "high": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Range"
+      },
+      "Ratio": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "numerator": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "denominator": {
+            "$ref": "#/components/schemas/Quantity"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Ratio"
+      },
+      "Reference": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "reference": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "type": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "identifier": {
+            "$ref": "#/components/schemas/Identifier"
+          },
+          "display": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/references.html"
+      },
+      "ReferenceRange": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "low": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "high": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "appliesTo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "age": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "RelatedArtifact": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "documentation",
+              "justification",
+              "citation",
+              "predecessor",
+              "successor",
+              "derived-from",
+              "depends-on",
+              "composed-of"
+            ]
+          },
+          "label": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "display": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "citation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "url": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "document": {
+            "$ref": "#/components/schemas/Attachment"
+          },
+          "resource": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#relatedartifact"
+      },
+      "Request": {
+        "type": "object",
+        "description": "https://hl7.org/fhir/R4/bundle.html"
+      },
+      "Resource": {
+        "type": "object",
+        "description": "https://www.hl7.org/fhir/R4/resource.html"
+      },
+      "ResourceInteraction": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "read",
+              "vread",
+              "update",
+              "patch",
+              "delete",
+              "history-instance",
+              "history-type",
+              "create",
+              "search-type"
+            ]
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        }
+      },
+      "Response": {
+        "type": "object",
+        "description": "https://hl7.org/fhir/R4/bundle.html"
+      },
+      "Rest": {
+        "required": [
+          "mode"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "client",
+              "server"
+            ]
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          },
+          "security": {
+            "$ref": "#/components/schemas/Security"
+          },
+          "resource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CapabilityResource"
+            }
+          },
+          "interaction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RestInteraction"
+            }
+          },
+          "searchParam": {
+            "$ref": "#/components/schemas/SearchParam"
+          },
+          "operation": {
+            "$ref": "#/components/schemas/Operation"
+          },
+          "compartment": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        }
+      },
+      "RestInteraction": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "transaction",
+              "batch",
+              "search-system",
+              "history-system"
+            ]
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        }
+      },
+      "SampledData": {
+        "required": [
+          "dimensions",
+          "origin",
+          "period"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "origin": {
+            "$ref": "#/components/schemas/SimpleQuantity"
+          },
+          "period": {
+            "type": "number"
+          },
+          "factor": {
+            "type": "number"
+          },
+          "lowerLimit": {
+            "type": "number"
+          },
+          "upperLimit": {
+            "type": "number"
+          },
+          "dimensions": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "data": {
+            "type": "string"
+          }
+        },
+        "description": "http://hl7.org/fhir/R4/datatypes.html#SampledData"
+      },
+      "Search": {
+        "type": "object",
+        "description": "https://hl7.org/fhir/R4/bundle.html"
+      },
+      "SearchParam": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "definition": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "number",
+              "date",
+              "string",
+              "token",
+              "reference",
+              "composite",
+              "quantity",
+              "uri",
+              "special"
+            ]
+          },
+          "documentation": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        }
+      },
+      "Security": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "cors": {
+            "type": "boolean"
+          },
+          "service": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CodeableConcept"
+            }
+          },
+          "description": {
+            "pattern": "\\s*(\\S|\\s)*",
+            "type": "string"
+          }
+        }
+      },
+      "Signature": {
+        "required": [
+          "type",
+          "when",
+          "who"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Coding"
+            }
+          },
+          "when": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))",
+            "type": "string"
+          },
+          "who": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "onBehalfOf": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "targetFormat": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "sigFormat": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          },
+          "data": {
+            "pattern": "(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+",
+            "type": "string"
+          }
+        },
+        "description": "http://hl7.org/fhir/R4/datatypes.html#Signature"
+      },
+      "SimpleQuantity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "value": {
+            "type": "number"
+          },
+          "unit": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "system": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "code": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#SimpleQuantity"
+      },
+      "Software": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "version": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "releaseDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          }
+        }
+      },
+      "Sort": {
+        "required": [
+          "direction",
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "path": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "direction": {
+            "pattern": "[^\\s]+(\\s[^\\s]+)*",
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          }
+        }
+      },
+      "StatusHistory": {
+        "required": [
+          "period",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "planned",
+              "arrived",
+              "triaged",
+              "in-progress",
+              "onleave",
+              "finished",
+              "cancelled",
+              "entered-in-error",
+              "unknown"
+            ]
+          },
+          "period": {
+            "$ref": "#/components/schemas/Period"
+          }
+        }
+      },
+      "SupportedMessage": {
+        "required": [
+          "definition",
+          "mode"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "sender",
+              "receiver"
+            ]
+          },
+          "definition": {
+            "pattern": "\\S*",
+            "type": "string"
+          }
+        }
+      },
+      "Timing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "event": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "repeat": {
+            "$ref": "#/components/schemas/TimingRepeat"
+          },
+          "code": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/datatypes.html#Timing"
+      },
+      "TimingRepeat": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "boundsDuration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "boundsRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "boundsPeriod": {
+            "$ref": "#/components/schemas/Period"
+          },
+          "count": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "countMax": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "duration": {
+            "type": "number"
+          },
+          "durationMax": {
+            "type": "number"
+          },
+          "durationUnit": {
+            "type": "string",
+            "enum": [
+              "s",
+              "min",
+              "h",
+              "d",
+              "wk",
+              "mo",
+              "a"
+            ]
+          },
+          "frequency": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "frequencyMax": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "period": {
+            "type": "number"
+          },
+          "periodMax": {
+            "type": "number"
+          },
+          "periodUnit": {
+            "type": "string",
+            "enum": [
+              "s",
+              "min",
+              "h",
+              "d",
+              "wk",
+              "mo",
+              "a"
+            ]
+          },
+          "dayOfWeek": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "mon",
+                "tue",
+                "wed",
+                "thu",
+                "fri",
+                "sat",
+                "sun"
+              ]
+            }
+          },
+          "timeOfDay": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "when": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "MORN",
+                "MORN.early",
+                "MORN.late",
+                "NOON",
+                "AFT",
+                "AFT.early",
+                "AFT.late",
+                "EVE",
+                "EVE.early",
+                "EVE.late",
+                "NIGHT",
+                "PHS",
+                "HS",
+                "WAKE",
+                "C",
+                "CM",
+                "CD",
+                "CV",
+                "AC",
+                "ACM",
+                "ACD",
+                "ACV",
+                "PC",
+                "PCM",
+                "PCD",
+                "PCV"
+              ]
+            }
+          },
+          "offset": {
+            "minimum": 0,
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TriggerDefinition": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "named-event",
+              "periodic",
+              "data-changed",
+              "data-added",
+              "data-modified",
+              "data-removed",
+              "data-accessed",
+              "data-access-ended"
+            ]
+          },
+          "name": {
+            "pattern": "[ \\r\\n\\t\\S]+",
+            "type": "string"
+          },
+          "timingTiming": {
+            "$ref": "#/components/schemas/Timing"
+          },
+          "timingReference": {
+            "$ref": "#/components/schemas/Reference"
+          },
+          "timingDate": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?",
+            "type": "string"
+          },
+          "timingDateTime": {
+            "pattern": "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?",
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataRequirement"
+            }
+          },
+          "condition": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#triggerdefinition"
+      },
+      "UniqueDeviceIdentifier": {
+        "required": [
+          "deviceIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "modifierExtension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "deviceIdentifier": {
+            "type": "string"
+          },
+          "issuer": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "jurisdiction": {
+            "pattern": "\\S*",
+            "type": "string"
+          },
+          "entryType": {
+            "type": "string",
+            "enum": [
+              "barcode",
+              "rfid",
+              "manual",
+              "card",
+              "self-reported",
+              "unknown"
+            ]
+          },
+          "carrierAIDC": {
+            "pattern": "(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+",
+            "type": "string"
+          },
+          "carrierHRF": {
+            "type": "string"
+          }
+        }
+      },
+      "UsageContext": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "[A-Za-z0-9\\-\\.]{1,64}",
+            "type": "string"
+          },
+          "extension": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extension"
+            }
+          },
+          "code": {
+            "$ref": "#/components/schemas/Coding"
+          },
+          "valueCodeableConcept": {
+            "$ref": "#/components/schemas/CodeableConcept"
+          },
+          "valueQuantity": {
+            "$ref": "#/components/schemas/Quantity"
+          },
+          "valueRange": {
+            "$ref": "#/components/schemas/Range"
+          },
+          "valueReference": {
+            "$ref": "#/components/schemas/Reference"
+          }
+        },
+        "description": "https://www.hl7.org/fhir/R4/metadatatypes.html#UsageContext"
+      }
+    },
+    "securitySchemes": {
+      "OauthFlowSandbox": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://sandbox-api.va.gov/oauth2/authorization",
+            "tokenUrl": "https://sandbox-api.va.gov/services/fhir/v0/r4/token",
+            "scopes": {
+              "patient/AllergyIntolerance.read": "read allergy intolerances",
+              "system/Appointment.read": "read appointments",
+              "patient/Condition.read": "read conditions",
+              "patient/Device.read": "read devices",
+              "patient/DiagnosticReport.read": "read diagnostic reports",
+              "patient/Encounter.read": "read encounters",
+              "patient/Immunization.read": "read immunizations",
+              "patient/Medication.read": "read medications",
+              "patient/MedicationRequest.read": "read medication requests",
+              "patient/Observation.read": "read observations",
+              "patient/Patient.read": "read patient",
+              "patient/Practitioner.read": "read practitioner",
+              "patient/PractitionerRole.read": "read practitioner roles",
+              "patient/Procedure.read": "read procedures",
+              "offline_access": "offline access",
+              "launch/patient": "patient launch"
+            }
+          }
+        }
+      },
+      "OauthFlowProduction": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.va.gov/oauth2/authorization",
+            "tokenUrl": "https://api.va.gov/services/fhir/v0/r4/token",
+            "scopes": {
+              "patient/AllergyIntolerance.read": "read allergy intolerances",
+              "system/Appointment.read": "read appointments",
+              "patient/Condition.read": "read conditions",
+              "patient/Device.read": "read devices",
+              "patient/DiagnosticReport.read": "read diagnostic reports",
+              "patient/Encounter.read": "read encounters",
+              "patient/Immunization.read": "read immunizations",
+              "patient/Medication.read": "read medications",
+              "patient/MedicationRequest.read": "read medication requests",
+              "patient/Observation.read": "read observations",
+              "patient/Patient.read": "read patient",
+              "patient/Practitioner.read": "read practitioner",
+              "patient/PractitionerRole.read": "read practitioner roles",
+              "patient/Procedure.read": "read procedures",
+              "offline_access": "offline access",
+              "launch/patient": "patient launch"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/securities/oauth2_token_oas.json
+++ b/test/fixtures/securities/oauth2_token_oas.json
@@ -52,12 +52,17 @@
         "operationId": "conditionSearch",
         "security": [
           {
-            "OauthFlowSandbox": [
+            "boromir-bearer": [
               "patient/Condition.read"
             ]
           },
           {
-            "OauthFlowProduction": [
+            "boromir-prod-oauth": [
+              "patient/Condition.read"
+            ]
+          },
+          {
+            "boromir-sandbox-oauth": [
               "patient/Condition.read"
             ]
           }


### PR DESCRIPTION
Adding logic to allow promptForSecurityValues function to handle the oauth2 security scheme type. 

Handles security scheme of type:oauth2 (see Security Scheme Object in OAS spec https://swagger.io/specification/) in order to handle some of the API's such as Clinical Health for LOAST.