### PR TITLE
Api 13583/reduce size and eliminate duplicate code

### DIFF
--- a/src/utilities/oas-operation/oas-operation.ts
+++ b/src/utilities/oas-operation/oas-operation.ts
@@ -26,9 +26,9 @@ class OASOperation {
     this.operationId = operation.operationId;
     this.parameters = operation.parameters;
     this._exampleGroups = ExampleGroupFactory.buildFromOperation(this);
-
-    operation.security = operation.security ?? securities;
-    this.security = OASSecurityFactory.getSecurities(operation.security);
+    this.security = OASSecurityFactory.getSecurities(
+      operation.security ?? securities,
+    );
   }
 
   get exampleGroups(): ExampleGroup[] {

--- a/test/commands/positive.test-objects.ts
+++ b/test/commands/positive.test-objects.ts
@@ -95,4 +95,106 @@ const getTomBombadil: OperationObject = {
   ],
 };
 
-export { getHobbit, getHobbits, getTomBombadil };
+const walkIntoMordorIntEx: OperationObject = {
+  operationId: 'walkIntoMordor',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'guide',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      required: true,
+      example: 42,
+    },
+  ],
+};
+
+const walkIntoMordorStrEx: OperationObject = {
+  operationId: 'walkIntoMordor',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'guide',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      required: true,
+      example: 'golem',
+    },
+  ],
+};
+
+const walkIntoMordorIntExs: OperationObject = {
+  operationId: 'walkIntoMordor',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'door',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      examples: {
+        door: {
+          value: 2,
+        },
+      },
+    },
+    {
+      name: 'guide',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      examples: {
+        guided: {
+          value: 'gollum',
+        },
+      },
+    },
+  ],
+};
+
+const walkIntoMordorStrExs: OperationObject = {
+  operationId: 'walkIntoMordor',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'door',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      examples: {
+        door: {
+          value: 'front',
+        },
+      },
+    },
+    {
+      name: 'guide',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      examples: {
+        guided: {
+          value: 'gollum',
+        },
+      },
+    },
+  ],
+};
+
+export {
+  getHobbit,
+  getHobbits,
+  getTomBombadil,
+  walkIntoMordorIntEx,
+  walkIntoMordorStrEx,
+  walkIntoMordorIntExs,
+  walkIntoMordorStrExs,
+};

--- a/test/commands/positive.test-objects.ts
+++ b/test/commands/positive.test-objects.ts
@@ -1,0 +1,98 @@
+import { OperationObject, ResponseObject } from 'swagger-client/schema';
+
+const defaultResponses: { [responseCode: string]: ResponseObject } = {
+  '200': {
+    description: '',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const hobbitsResponse: { [responseCode: string]: ResponseObject } = {
+  '200': {
+    description: '',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  one: {
+                    type: 'number',
+                  },
+                  two: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const getHobbit: OperationObject = {
+  operationId: 'getHobbit',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      example: 'Frodo',
+    },
+  ],
+};
+
+const getHobbits: OperationObject = {
+  operationId: 'getHobbits',
+  responses: hobbitsResponse,
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      schema: {
+        type: 'string',
+      },
+      example: 'Frodo',
+    },
+  ],
+};
+
+const getTomBombadil: OperationObject = {
+  operationId: 'getTomBombadil',
+  responses: defaultResponses,
+  parameters: [
+    {
+      name: 'times',
+      in: 'query',
+      example: 2,
+      schema: {
+        type: 'number',
+      },
+    },
+  ],
+};
+
+export { getHobbit, getHobbits, getTomBombadil };

--- a/test/commands/positive.test-objects.ts
+++ b/test/commands/positive.test-objects.ts
@@ -95,7 +95,7 @@ const getTomBombadil: OperationObject = {
   ],
 };
 
-const walkIntoMordorIntEx: OperationObject = {
+const walkIntoMordorSingleIntegerTest: OperationObject = {
   operationId: 'walkIntoMordor',
   responses: defaultResponses,
   parameters: [
@@ -111,7 +111,7 @@ const walkIntoMordorIntEx: OperationObject = {
   ],
 };
 
-const walkIntoMordorStrEx: OperationObject = {
+const walkIntoMordorSingleStringTest: OperationObject = {
   operationId: 'walkIntoMordor',
   responses: defaultResponses,
   parameters: [
@@ -127,7 +127,7 @@ const walkIntoMordorStrEx: OperationObject = {
   ],
 };
 
-const walkIntoMordorIntExs: OperationObject = {
+const walkIntoMordorMultiIntegerTest: OperationObject = {
   operationId: 'walkIntoMordor',
   responses: defaultResponses,
   parameters: [
@@ -158,7 +158,7 @@ const walkIntoMordorIntExs: OperationObject = {
   ],
 };
 
-const walkIntoMordorStrExs: OperationObject = {
+const walkIntoMordorMultiStringTest: OperationObject = {
   operationId: 'walkIntoMordor',
   responses: defaultResponses,
   parameters: [
@@ -193,8 +193,8 @@ export {
   getHobbit,
   getHobbits,
   getTomBombadil,
-  walkIntoMordorIntEx,
-  walkIntoMordorStrEx,
-  walkIntoMordorIntExs,
-  walkIntoMordorStrExs,
+  walkIntoMordorSingleIntegerTest,
+  walkIntoMordorSingleStringTest,
+  walkIntoMordorMultiIntegerTest,
+  walkIntoMordorMultiStringTest,
 };

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -3,6 +3,7 @@ const mockPrompt = jest.fn();
 import Positive from '../../src/commands/positive';
 import OASOperation from '../../src/utilities/oas-operation';
 import OASServer from '../../src/utilities/oas-server/oas-server';
+import { getHobbit, getHobbits, getTomBombadil } from './positive.test-objects';
 
 const mockGetOperations = jest.fn();
 const mockGetServers = jest.fn();
@@ -78,40 +79,8 @@ describe('Positive', () => {
         },
         [{ 'boromir-security': [] }],
       ),
-      new OASOperation(
-        {
-          operationId: 'getHobbit',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'name',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              example: 'Frodo',
-            },
-          ],
-        },
-        [{ 'boromir-security': [] }],
-      ),
-      new OASOperation(
-        {
-          operationId: 'getTomBombadil',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'times',
-              in: 'query',
-              example: 2,
-              schema: {
-                type: 'number',
-              },
-            },
-          ],
-        },
-        [{ 'faramir-security': [] }],
-      ),
+      new OASOperation(getHobbit, [{ 'boromir-security': [] }]),
+      new OASOperation(getTomBombadil, [{ 'faramir-security': [] }]),
     ]);
 
     mockGetServers.mockReset();
@@ -176,34 +145,8 @@ describe('Positive', () => {
           },
         ],
       });
-      const operation2 = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      const operation3 = new OASOperation({
-        operationId: 'getTomBombadil',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'times',
-            in: 'query',
-            example: 2,
-            schema: {
-              type: 'number',
-            },
-          },
-        ],
-      });
+      const operation2 = new OASOperation(getHobbit);
+      const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
 
       const security = {};
@@ -272,34 +215,8 @@ describe('Positive', () => {
           },
         ],
       });
-      const operation2 = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      const operation3 = new OASOperation({
-        operationId: 'getTomBombadil',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'times',
-            in: 'query',
-            example: 2,
-            schema: {
-              type: 'number',
-            },
-          },
-        ],
-      });
+      const operation2 = new OASOperation(getHobbit);
+      const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
 
       mockExecute.mockResolvedValueOnce({
@@ -395,20 +312,7 @@ describe('Positive', () => {
   });
 
   describe('promptForServerValue', () => {
-    const operation = new OASOperation({
-      operationId: 'getHobbit',
-      responses: defaultResponses,
-      parameters: [
-        {
-          name: 'name',
-          in: 'query',
-          schema: {
-            type: 'string',
-          },
-          example: 'Frodo',
-        },
-      ],
-    });
+    const operation = new OASOperation(getHobbit);
 
     beforeEach(() => {
       mockGetOperations.mockResolvedValue([operation]);
@@ -663,47 +567,7 @@ describe('Positive', () => {
   });
 
   describe('output', () => {
-    const operation = new OASOperation({
-      operationId: 'getHobbits',
-      responses: {
-        '200': {
-          description: '',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  data: {
-                    type: 'array',
-                    items: {
-                      type: 'object',
-                      properties: {
-                        one: {
-                          type: 'number',
-                        },
-                        two: {
-                          type: 'string',
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      parameters: [
-        {
-          name: 'name',
-          in: 'query',
-          schema: {
-            type: 'string',
-          },
-          example: 'Frodo',
-        },
-      ],
-    });
+    const operation = new OASOperation(getHobbits);
 
     beforeEach(() => {
       mockGetOperations.mockResolvedValue([operation]);
@@ -739,34 +603,8 @@ describe('Positive', () => {
     });
 
     it('On multiple operation failures, output error(s) and operation failure(s)', async () => {
-      const operation2 = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      const operation3 = new OASOperation({
-        operationId: 'getTomBombadil',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'times',
-            in: 'query',
-            example: 2,
-            schema: {
-              type: 'number',
-            },
-          },
-        ],
-      });
+      const operation2 = new OASOperation(getHobbit);
+      const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation2, operation3]);
 
       mockExecute.mockResolvedValue({
@@ -794,34 +632,8 @@ describe('Positive', () => {
     });
 
     it('On single non-ok response status, output error and failure', async () => {
-      const operation2 = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
-      const operation3 = new OASOperation({
-        operationId: 'getTomBombadil',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'times',
-            in: 'query',
-            example: 2,
-            schema: {
-              type: 'number',
-            },
-          },
-        ],
-      });
+      const operation2 = new OASOperation(getHobbit);
+      const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation2, operation3]);
 
       mockExecute.mockResolvedValueOnce({

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -1,4 +1,3 @@
-import { ResponseObject } from 'swagger-client';
 const mockPrompt = jest.fn();
 import Positive from '../../src/commands/positive';
 import OASOperation from '../../src/utilities/oas-operation';
@@ -39,26 +38,6 @@ jest.mock('cli-ux', () => {
 
 describe('Positive', () => {
   let result;
-  const defaultResponses: { [responseCode: string]: ResponseObject } = {
-    '200': {
-      description: '',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            properties: {
-              data: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  };
 
   beforeEach(() => {
     result = [];
@@ -197,20 +176,7 @@ describe('Positive', () => {
     });
 
     it('Successful load of YAML file type specification', async () => {
-      const operation = new OASOperation({
-        operationId: 'getHobbit',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'name',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            example: 'Frodo',
-          },
-        ],
-      });
+      const operation = new OASOperation(getHobbit);
       mockGetOperations.mockResolvedValue([operation]);
 
       mockExecute.mockResolvedValueOnce({

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -3,7 +3,15 @@ const mockPrompt = jest.fn();
 import Positive from '../../src/commands/positive';
 import OASOperation from '../../src/utilities/oas-operation';
 import OASServer from '../../src/utilities/oas-server/oas-server';
-import { getHobbit, getHobbits, getTomBombadil } from './positive.test-objects';
+import {
+  getHobbit,
+  getHobbits,
+  getTomBombadil,
+  walkIntoMordorIntEx,
+  walkIntoMordorStrEx,
+  walkIntoMordorIntExs,
+  walkIntoMordorStrExs,
+} from './positive.test-objects';
 
 const mockGetOperations = jest.fn();
 const mockGetServers = jest.fn();
@@ -61,24 +69,7 @@ describe('Positive', () => {
     mockPrompt.mockReset();
     mockGetOperations.mockReset();
     mockGetOperations.mockResolvedValue([
-      new OASOperation(
-        {
-          operationId: 'walkIntoMordor',
-          responses: defaultResponses,
-          parameters: [
-            {
-              name: 'guide',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              required: true,
-              example: 'golem',
-            },
-          ],
-        },
-        [{ 'boromir-security': [] }],
-      ),
+      new OASOperation(walkIntoMordorStrEx, [{ 'boromir-security': [] }]),
       new OASOperation(getHobbit, [{ 'boromir-security': [] }]),
       new OASOperation(getTomBombadil, [{ 'faramir-security': [] }]),
     ]);
@@ -115,36 +106,7 @@ describe('Positive', () => {
 
   describe('OAS operation has parameter groups', () => {
     it('does not execute a request for a parameter group that fails parameter validation', async () => {
-      const operation1 = new OASOperation({
-        operationId: 'walkIntoMordor',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'door',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            examples: {
-              door: {
-                value: 2,
-              },
-            },
-          },
-          {
-            name: 'guide',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            examples: {
-              guided: {
-                value: 'gollum',
-              },
-            },
-          },
-        ],
-      });
+      const operation1 = new OASOperation(walkIntoMordorIntExs);
       const operation2 = new OASOperation(getHobbit);
       const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
@@ -185,36 +147,7 @@ describe('Positive', () => {
     });
 
     it('Validate response(s) for each parameter group', async () => {
-      const operation1 = new OASOperation({
-        operationId: 'walkIntoMordor',
-        responses: defaultResponses,
-        parameters: [
-          {
-            name: 'door',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            examples: {
-              door: {
-                value: 'front',
-              },
-            },
-          },
-          {
-            name: 'guide',
-            in: 'query',
-            schema: {
-              type: 'string',
-            },
-            examples: {
-              guided: {
-                value: 'gollum',
-              },
-            },
-          },
-        ],
-      });
+      const operation1 = new OASOperation(walkIntoMordorStrExs);
       const operation2 = new OASOperation(getHobbit);
       const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
@@ -575,21 +508,7 @@ describe('Positive', () => {
 
     it('On parameter validation failure, output operation failure', async () => {
       mockGetOperations.mockResolvedValue([
-        new OASOperation({
-          operationId: 'walkIntoMordor',
-          parameters: [
-            {
-              name: 'guide',
-              in: 'query',
-              schema: {
-                type: 'string',
-              },
-              required: true,
-              example: 42,
-            },
-          ],
-          responses: defaultResponses,
-        }),
+        new OASOperation(walkIntoMordorIntEx),
       ]);
 
       await expect(async () => {

--- a/test/commands/positive.test.ts
+++ b/test/commands/positive.test.ts
@@ -6,10 +6,10 @@ import {
   getHobbit,
   getHobbits,
   getTomBombadil,
-  walkIntoMordorIntEx,
-  walkIntoMordorStrEx,
-  walkIntoMordorIntExs,
-  walkIntoMordorStrExs,
+  walkIntoMordorSingleIntegerTest,
+  walkIntoMordorSingleStringTest,
+  walkIntoMordorMultiIntegerTest,
+  walkIntoMordorMultiStringTest,
 } from './positive.test-objects';
 
 const mockGetOperations = jest.fn();
@@ -48,7 +48,9 @@ describe('Positive', () => {
     mockPrompt.mockReset();
     mockGetOperations.mockReset();
     mockGetOperations.mockResolvedValue([
-      new OASOperation(walkIntoMordorStrEx, [{ 'boromir-security': [] }]),
+      new OASOperation(walkIntoMordorSingleStringTest, [
+        { 'boromir-security': [] },
+      ]),
       new OASOperation(getHobbit, [{ 'boromir-security': [] }]),
       new OASOperation(getTomBombadil, [{ 'faramir-security': [] }]),
     ]);
@@ -85,7 +87,7 @@ describe('Positive', () => {
 
   describe('OAS operation has parameter groups', () => {
     it('does not execute a request for a parameter group that fails parameter validation', async () => {
-      const operation1 = new OASOperation(walkIntoMordorIntExs);
+      const operation1 = new OASOperation(walkIntoMordorMultiIntegerTest);
       const operation2 = new OASOperation(getHobbit);
       const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
@@ -126,7 +128,7 @@ describe('Positive', () => {
     });
 
     it('Validate response(s) for each parameter group', async () => {
-      const operation1 = new OASOperation(walkIntoMordorStrExs);
+      const operation1 = new OASOperation(walkIntoMordorMultiStringTest);
       const operation2 = new OASOperation(getHobbit);
       const operation3 = new OASOperation(getTomBombadil);
       mockGetOperations.mockResolvedValue([operation1, operation2, operation3]);
@@ -474,7 +476,7 @@ describe('Positive', () => {
 
     it('On parameter validation failure, output operation failure', async () => {
       mockGetOperations.mockResolvedValue([
-        new OASOperation(walkIntoMordorIntEx),
+        new OASOperation(walkIntoMordorSingleIntegerTest),
       ]);
 
       await expect(async () => {


### PR DESCRIPTION
This PR focuses on reducing clutter and size of postitive.test.ts. Test objects have been refactored into their own file - positive.test-objects.ts - and imported into postitive.test.ts making it easier to read and maintain. All local tests passed at the time this code was pushed.