### PR TITLE
API-17188/remove-mutual-tls

### DIFF
--- a/src/utilities/oas-security/oas-security-scheme.ts
+++ b/src/utilities/oas-security/oas-security-scheme.ts
@@ -3,7 +3,6 @@ import { SecuritySchemeObject } from 'swagger-client/schema';
 export enum OASSecurityType {
   APIKEY = 'apiKey',
   HTTP = 'http',
-  MUTUAL_TLS = 'mutualTLS',
   OAUTH2 = 'oauth2',
   OPEN_ID_CONNECT = 'openIdConnect',
 }


### PR DESCRIPTION
Removes MUTUAL_TLS from OASSecurityType scheme to ensure only valid OAS values are present.