### PR TITLE
feat: Exposed conductors and results

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
   "engines": {
     "node": ">=8.0.0"
   },
+  "exports": {
+    ".": "./lib/index.js",
+    "./conductors": "./lib/conductors/index.js",
+    "./results": "./lib/results/index.js"
+  },
   "files": [
     "/bin",
     "/lib",


### PR DESCRIPTION
- Added package.json change to allow LOAST to be consumed by other modules rather than requiring direct oclif calls

Work is connected to API-14912