### PR TITLE
API-20393 Resolved package vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Details surrounding the `core ruleset` can be found at [Spectral's OpenAPI-Rules
 
 # Local Development
 
-See our [contribution guide](CONTRIBUTING.MD)
+See our [contribution guide](CONTRIBUTING.md)
 
 ## Running Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,11 @@
         "content-type": "^1.0.4",
         "js-yaml": "^4.1.0",
         "load-json-file": "^6.2.0",
-        "loast": "^1.9.0",
         "lodash.isequal": "^4.5.0",
         "lodash.uniq": "^4.5.0",
         "lodash.uniqwith": "^4.5.0",
         "medium-type": "^1.0.0",
-        "parse-url": "^6.0.1",
+        "parse-path": "^7.0.0",
         "swagger-client": "^3.12.0"
       },
       "bin": {
@@ -5089,14 +5088,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -6272,14 +6263,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/find-node-modules": {
@@ -7548,14 +7531,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-ssh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
-      "dependencies": {
-        "protocols": "^2.0.1"
       }
     },
     "node_modules/is-stream": {
@@ -9414,58 +9389,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/loast": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/loast/-/loast-1.9.0.tgz",
-      "integrity": "sha512-fRclCHMyxCCqHpTZUKesffTanWyixAlV31g6rK0rH4vc0P7EJebUxIJ/cV1/XVXzM1yaj73DhTOYzrpa2EuP0A==",
-      "dependencies": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@oclif/plugin-help": "^3.2.0",
-        "cli-ux": "^5.5.1",
-        "content-type": "^1.0.4",
-        "js-yaml": "^4.1.0",
-        "load-json-file": "^6.2.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.uniq": "^4.5.0",
-        "lodash.uniqwith": "^4.5.0",
-        "parse-url": "^5.0.2",
-        "swagger-client": "^3.12.0"
-      },
-      "bin": {
-        "loast": "bin/run"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/loast/node_modules/parse-path": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-      "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
-      "dependencies": {
-        "is-ssh": "^1.3.0",
-        "protocols": "^1.4.0",
-        "qs": "^6.9.4",
-        "query-string": "^6.13.8"
-      }
-    },
-    "node_modules/loast/node_modules/parse-url": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.8.tgz",
-      "integrity": "sha512-KFg5QvyiOKJGQSwUT7c5A4ELs0TJ33gmx/NBjK0FvZUD6aonFuXHUVa3SIa2XpbYVkYU8VlDrD3oCbX1ufy0zg==",
-      "dependencies": {
-        "is-ssh": "^1.3.0",
-        "normalize-url": "^6.1.0",
-        "parse-path": "^4.0.4",
-        "protocols": "^1.4.0"
-      }
-    },
-    "node_modules/loast/node_modules/protocols": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -10122,6 +10045,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -12968,22 +12892,11 @@
       }
     },
     "node_modules/parse-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
-      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
       "dependencies": {
         "protocols": "^2.0.0"
-      }
-    },
-    "node_modules/parse-url": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.1.tgz",
-      "integrity": "sha512-EY1/ifgf9BnizQoS09a7xbUI7LOzqUsLgmY/5xe+W3XVpsbARDZmmrjPqyDx0mdioZPBpKbeTisAHrLLndX/Qw==",
-      "dependencies": {
-        "is-ssh": "^1.4.0",
-        "normalize-url": "^6.1.0",
-        "parse-path": "^5.0.0",
-        "protocols": "^2.0.1"
       }
     },
     "node_modules/password-prompt": {
@@ -13403,23 +13316,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
@@ -14381,14 +14277,6 @@
         "node": "*"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -14462,14 +14350,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -19295,11 +19175,6 @@
         }
       }
     },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
-    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -20184,11 +20059,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "find-node-modules": {
       "version": "2.1.2",
@@ -21109,14 +20979,6 @@
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "requires": {
         "call-bind": "^1.0.2"
-      }
-    },
-    "is-ssh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
-      "requires": {
-        "protocols": "^2.0.1"
       }
     },
     "is-stream": {
@@ -22487,54 +22349,6 @@
         }
       }
     },
-    "loast": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/loast/-/loast-1.9.0.tgz",
-      "integrity": "sha512-fRclCHMyxCCqHpTZUKesffTanWyixAlV31g6rK0rH4vc0P7EJebUxIJ/cV1/XVXzM1yaj73DhTOYzrpa2EuP0A==",
-      "requires": {
-        "@oclif/command": "^1.8.0",
-        "@oclif/config": "^1.17.0",
-        "@oclif/plugin-help": "^3.2.0",
-        "cli-ux": "^5.5.1",
-        "content-type": "^1.0.4",
-        "js-yaml": "^4.1.0",
-        "load-json-file": "^6.2.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.uniq": "^4.5.0",
-        "lodash.uniqwith": "^4.5.0",
-        "parse-url": "^5.0.2",
-        "swagger-client": "^3.12.0"
-      },
-      "dependencies": {
-        "parse-path": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.4.tgz",
-          "integrity": "sha512-Z2lWUis7jlmXC1jeOG9giRO2+FsuyNipeQ43HAjqAZjwSe3SEf+q/84FGPHoso3kyntbxa4c4i77t3m6fGf8cw==",
-          "requires": {
-            "is-ssh": "^1.3.0",
-            "protocols": "^1.4.0",
-            "qs": "^6.9.4",
-            "query-string": "^6.13.8"
-          }
-        },
-        "parse-url": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.8.tgz",
-          "integrity": "sha512-KFg5QvyiOKJGQSwUT7c5A4ELs0TJ33gmx/NBjK0FvZUD6aonFuXHUVa3SIa2XpbYVkYU8VlDrD3oCbX1ufy0zg==",
-          "requires": {
-            "is-ssh": "^1.3.0",
-            "normalize-url": "^6.1.0",
-            "parse-path": "^4.0.4",
-            "protocols": "^1.4.0"
-          }
-        },
-        "protocols": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
-          "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg=="
-        }
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -23055,7 +22869,8 @@
     "normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true
     },
     "npm": {
       "version": "8.16.0",
@@ -25040,22 +24855,11 @@
       "dev": true
     },
     "parse-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-5.0.0.tgz",
-      "integrity": "sha512-qOpH55/+ZJ4jUu/oLO+ifUKjFPNZGfnPJtzvGzKN/4oLMil5m9OH4VpOj6++9/ytJcfks4kzH2hhi87GL/OU9A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
       "requires": {
         "protocols": "^2.0.0"
-      }
-    },
-    "parse-url": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.1.tgz",
-      "integrity": "sha512-EY1/ifgf9BnizQoS09a7xbUI7LOzqUsLgmY/5xe+W3XVpsbARDZmmrjPqyDx0mdioZPBpKbeTisAHrLLndX/Qw==",
-      "requires": {
-        "is-ssh": "^1.4.0",
-        "normalize-url": "^6.1.0",
-        "parse-path": "^5.0.0",
-        "protocols": "^2.0.1"
       }
     },
     "password-prompt": {
@@ -25377,17 +25181,6 @@
       "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
       "requires": {
         "side-channel": "^1.0.4"
-      }
-    },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -26096,11 +25889,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -26173,11 +25961,6 @@
           }
         }
       }
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "content-type": "^1.0.4",
     "js-yaml": "^4.1.0",
     "load-json-file": "^6.2.0",
-    "loast": "^1.9.0",
+
     "lodash.isequal": "^4.5.0",
     "lodash.uniq": "^4.5.0",
     "lodash.uniqwith": "^4.5.0",
     "medium-type": "^1.0.0",
-    "parse-url": "^6.0.1",
+    "parse-path": "^7.0.0",
     "swagger-client": "^3.12.0"
   },
   "devDependencies": {

--- a/src/loast.ts
+++ b/src/loast.ts
@@ -1,6 +1,6 @@
 import { TestOptions } from './config';
 import { OASResult, OperationResult } from './validation';
-import parseUrl from 'parse-url';
+import parsePath from 'parse-path';
 import { FILE_PROTOCOL } from './utilities/constants';
 import OASSchema from './oas-parsing/schema';
 import { FileIn } from './utilities/file-in';
@@ -65,8 +65,8 @@ export default class Loast {
   private async populateSuiteConfig(): Promise<void> {
     const oasSchemaOptions: ConstructorParameters<typeof OASSchema>[0] = {};
 
-    const url = parseUrl(this.options.path);
-    if (url.protocol === FILE_PROTOCOL) {
+    const parsed = parsePath(this.options.path);
+    if (parsed.protocol === FILE_PROTOCOL) {
       oasSchemaOptions.spec = FileIn.loadSpecFromFile(this.options.path);
     } else {
       oasSchemaOptions.url = this.options.path;

--- a/src/utilities/file-in/file-in.ts
+++ b/src/utilities/file-in/file-in.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { extname, resolve } from 'path';
 import { Json } from 'swagger-client';
 import yaml from 'js-yaml';
-import parseUrl from 'parse-url';
+import parsePath from 'parse-path';
 import {
   FILE_PROTOCOL,
   JSON_FILE_EXTENSION,
@@ -41,8 +41,8 @@ export default class FileIn {
   }
 
   public static loadConfigFromFile(path: string): Json {
-    const url = parseUrl(path);
-    if (url.protocol !== FILE_PROTOCOL) {
+    const parsed = parsePath(path);
+    if (parsed.protocol !== FILE_PROTOCOL) {
       throw new Error('Path must be to a local file.');
     }
 


### PR DESCRIPTION
- Replaced calls to parseUrl with calls to parsePath directly, which was used internally by parsePath and is all we need
- Updated parse-path dependency in package.json and bumped to current version
- Removed circular dependency on loast package
- Fixed a typo in the readme
- Added FEAT tag to trigger a new release
