### PR TITLE
API-20569 - run oas tests even if no server is provided.

### DIFF
--- a/src/suites/positive/positive-suite.ts
+++ b/src/suites/positive/positive-suite.ts
@@ -39,7 +39,7 @@ export default class PositiveSuite extends Suite {
   }
 
   async conduct(): Promise<OperationResult[]> {
-    this.checkTargetServer();
+    await this.checkTargetServer();
 
     const results = await Promise.all(
       this.operationExamples.map(async (operationExample) => {

--- a/test/loast.test.ts
+++ b/test/loast.test.ts
@@ -105,6 +105,49 @@ describe('Loast', () => {
       });
     });
 
+    it('test api with invalid positive suite config and valid oas suite', async () => {
+      const optionsWithoutServer = {
+        path: 'https://westeros.dragonstone/underground/scrolls/catacombs/v0/openapi.json',
+        apiKey: 'fake-key',
+        suiteIds: [PositiveSuite.suiteId, OasRulesetSuite.suiteId],
+      };
+
+      const erroredOASResult = new OASResult(
+        PositiveSuite.suiteId,
+        'winterfell stronghold',
+        options.path,
+        undefined,
+        [securitySchemeAPIKey],
+        undefined,
+        'Server value must be specified if OAS contains more than one server',
+      );
+
+      SuiteFactory.build = jest.fn().mockReturnValue({
+        getLabel: jest.fn().mockReturnValue('stronghold'),
+        conduct: jest
+          .fn()
+          .mockRejectedValueOnce(
+            new Error(
+              'Server value must be specified if OAS contains more than one server',
+            ),
+          )
+          .mockResolvedValue([operationExampleResultFailuresWarnings]),
+      });
+
+      const results = await new Loast(
+        'winterfell',
+        optionsWithoutServer,
+      ).getResults();
+
+      expect(results.length).toEqual(2);
+      expect(results[0]).toEqual(erroredOASResult);
+      expect(results[1]).toEqual({
+        ...expectedOASResult,
+        suiteId: OasRulesetSuite.suiteId,
+        server: undefined,
+      });
+    });
+
     it('test api with all test suites', async () => {
       options.suiteIds = undefined;
       const totalSuites = SuiteFactory.availableSuiteIds();

--- a/test/suites/positive/positive-suite.test.ts
+++ b/test/suites/positive/positive-suite.test.ts
@@ -51,6 +51,23 @@ describe('PositiveSuite', () => {
 
       expect(await suite.conduct()).toEqual(oasResults);
     });
+
+    it('throws an error when no server is provided', async () => {
+      const suiteConfigWithoutServer = {
+        options: {
+          path: 'https://westeros.stormsend/underground/scrolls/catacombs/v0/openapi.json',
+          apiKey: 'fake_api_key',
+        },
+        schema: oasSchema,
+      };
+
+      const suite = new PositiveSuite();
+      await suite.setup(suiteConfigWithoutServer);
+
+      await expect(suite.conduct()).rejects.toThrow(
+        'Server value must be specified if OAS contains more than one server',
+      );
+    });
   });
 
   describe('getLabel', () => {


### PR DESCRIPTION
The `bin/suites` command now runs the oas suite even if no server is provided or the server is invalid. 

Previously, if an error was thrown inside of the positive suite, it would propagate up and prevent the oas test from being run. Now, the error is handled gracefully and printed to the output. The positive suite will also be skipped, allowing the oas suite to still run.

Example output (if no server is provided):
```
test (Example Group: 2xx Response) positive: Skipped - 'Server value must be specified if OAS contains more than one server'
test (oas-ruleset) oas-ruleset: 7/129 operations failed
```