### PR TITLE
fix(oas-ruleset suite): update va-param-example-required rule

### DIFF
--- a/src/suites/oas-ruleset/validation/ruleset.yaml
+++ b/src/suites/oas-ruleset/validation/ruleset.yaml
@@ -76,7 +76,7 @@ rules:
       function: truthy
   va-param-example-required:
     description: Parameters marked as required must have an example or examples property
-    given: $..*.parameters[?(@.required == true)]
+    given: $..*.parameters[?(@ && @.required == true)]
     severity: error
     then:
       function: xor


### PR DESCRIPTION
This PR is for [API-24174](https://vajira.max.gov/browse/API-24174). It updates the oas-ruleset va-param-example-required rule syntax to only check the required property if the parameter is not null.