### PR TITLE
fix: API-21737 When an Accept parameter is present in an example its value…

### DIFF
--- a/@types/swagger-client/index.d.ts
+++ b/@types/swagger-client/index.d.ts
@@ -19,6 +19,7 @@ declare module 'swagger-client' {
     requestBody?: RequestBody;
     server?: string;
     requestInterceptor?: (request: Request) => Request;
+    responseContentType?: string;
   }
 
   export interface Request {

--- a/src/oas-parsing/schema/oas-schema.ts
+++ b/src/oas-parsing/schema/oas-schema.ts
@@ -65,6 +65,13 @@ class OASSchema {
       options = { server, ...options };
     }
 
+    if (
+      options.parameters?.Accept !== undefined &&
+      options.parameters?.Accept.length > 0
+    ) {
+      options.responseContentType = options.parameters?.Accept;
+    }
+
     return schema.execute(options).catch((error) => {
       return error.response;
     });

--- a/src/oas-parsing/schema/oas-schema.ts
+++ b/src/oas-parsing/schema/oas-schema.ts
@@ -73,7 +73,7 @@ class OASSchema {
         (parameter) => parameter.name === 'Accept' && parameter.in === 'header',
       ) !== undefined
     ) {
-      options.responseContentType = options.parameters?.Accept;
+      options.responseContentType = options.parameters.Accept;
     }
 
     return schema.execute(options).catch((error) => {

--- a/src/oas-parsing/schema/oas-schema.ts
+++ b/src/oas-parsing/schema/oas-schema.ts
@@ -65,9 +65,13 @@ class OASSchema {
       options = { server, ...options };
     }
 
+    // if the example group contains an Accept header parameter,
+    // copy that over to responseContentType so it gets added to the header by the swagger client
     if (
-      options.parameters?.Accept !== undefined &&
-      options.parameters?.Accept.length > 0
+      options.parameters?.Accept !== undefined && // an inexpensive initial test
+      operation.parameters?.find(
+        (parameter) => parameter.name === 'Accept' && parameter.in === 'header',
+      ) !== undefined
     ) {
       options.responseContentType = options.parameters?.Accept;
     }

--- a/test/oas-parsing/schema/oas-schema.test.ts
+++ b/test/oas-parsing/schema/oas-schema.test.ts
@@ -66,6 +66,20 @@ describe('OASSchema', () => {
               description: 'a number',
             },
           },
+          {
+            name: 'Accept',
+            in: 'header',
+            required: true,
+            example: 'application/geo+json',
+            schema: {
+              type: 'string',
+              enum: [
+                'application/geo+json',
+                'application/vnd.geo+json',
+                'text/csv',
+              ],
+            },
+          },
         ],
         requestBody: {
           required: true,
@@ -121,6 +135,7 @@ describe('OASSchema', () => {
         operationId: 'getFacilityById',
         parameters: {
           id: 'testId',
+          Accept: 'application/geo+json',
         },
         requestBody: {
           id: 'secondTestId',
@@ -129,6 +144,7 @@ describe('OASSchema', () => {
           authorized: {},
         },
         server,
+        responseContentType: 'application/geo+json',
       });
     });
   });


### PR DESCRIPTION
… is copied to responseContentType so the swagger client picks it up properly