### PR TITLE
fix(positive suite): API-27125 - Add request body missing properties warning message

### DIFF
--- a/src/suites/positive/utilities/constants.ts
+++ b/src/suites/positive/utilities/constants.ts
@@ -1,0 +1,1 @@
+export const REQUEST_BODY_PATH = 'requestBody';

--- a/src/suites/positive/validation/positive-message.ts
+++ b/src/suites/positive/validation/positive-message.ts
@@ -2,7 +2,8 @@ import { Severity, MessageTemplate, Message } from '../../../validation';
 
 export enum Type {
   EmptyArray,
-  MissingProperties,
+  RequestBodyMissingProperties,
+  ResponseMissingProperties,
   ContentTypeMismatch,
   DuplicateEnum,
   EnumMismatch,
@@ -30,7 +31,12 @@ const messageTemplates: Record<Type, MessageTemplate> = {
     details:
       'Warning: This array was found to be empty and therefore could not be validated.',
   },
-  [Type.MissingProperties]: {
+  [Type.RequestBodyMissingProperties]: {
+    severity: Severity.WARNING,
+    details:
+      'Warning: Request body is missing non-required properties that were unable to be validated, including {0}.',
+  },
+  [Type.ResponseMissingProperties]: {
     severity: Severity.WARNING,
     details:
       'Warning: Response object is missing non-required properties that were unable to be validated, including {0}.',

--- a/src/suites/positive/validation/positive-validator.ts
+++ b/src/suites/positive/validation/positive-validator.ts
@@ -2,6 +2,7 @@ import { isEqual, uniqWith } from 'lodash';
 import { Json, SchemaObject } from 'swagger-client/schema';
 import { BaseValidator } from '../../../validation';
 import { Message } from '../../../validation';
+import { REQUEST_BODY_PATH } from '../utilities/constants';
 import PositiveMessage, { Type } from './positive-message';
 
 abstract class PositiveValidator extends BaseValidator {
@@ -206,7 +207,11 @@ abstract class PositiveValidator extends BaseValidator {
     );
 
     if (missingOptionalProperties.length > 0) {
-      this.addMessage(Type.MissingProperties, path, [
+      const warningType =
+        path[0] === REQUEST_BODY_PATH
+          ? Type.RequestBodyMissingProperties
+          : Type.ResponseMissingProperties;
+      this.addMessage(warningType, path, [
         missingOptionalProperties.join(', '),
       ]);
     }

--- a/src/suites/positive/validation/request-body-validator.ts
+++ b/src/suites/positive/validation/request-body-validator.ts
@@ -2,6 +2,7 @@ import { RequestBodyObject } from 'swagger-client/schema';
 import OASOperation from '../../../oas-parsing/operation';
 import PositiveValidator from './positive-validator';
 import { Type } from './positive-message';
+import { REQUEST_BODY_PATH } from '../utilities/constants';
 
 class RequestBodyValidator extends PositiveValidator {
   private operation: OASOperation;
@@ -19,7 +20,7 @@ class RequestBodyValidator extends PositiveValidator {
   };
 
   private checkRequestBody(requestBody: RequestBodyObject): void {
-    const path: string[] = ['requestBody'];
+    const path: string[] = [REQUEST_BODY_PATH];
 
     // check for content schema presence
     const contentObjectKeys = Object.keys(requestBody.content);

--- a/test/suites/positive/fixtures/warnings.ts
+++ b/test/suites/positive/fixtures/warnings.ts
@@ -5,20 +5,20 @@ import {
 } from '../../../../src/suites/positive/validation';
 
 const missingPropertyMiddleName = new PositiveMessage(
-  Type.MissingProperties,
+  Type.ResponseMissingProperties,
   ['body'],
   [['middleName'].join(', ')],
 );
 missingPropertyMiddleName.incrementCount();
 
 const missingPropertyAddress2 = new PositiveMessage(
-  Type.MissingProperties,
+  Type.ResponseMissingProperties,
   ['body', 'horcruxes', 'location'],
   [['address2'].join(', ')],
 );
 
 const requestBodyMissingProperties = new PositiveMessage(
-  Type.MissingProperties,
+  Type.RequestBodyMissingProperties,
   ['requestBody', 'example', 'horcruxes', 'location'],
   [['address2', 'name'].join(', ')],
 );

--- a/test/suites/positive/validation/request-body-validator.test.ts
+++ b/test/suites/positive/validation/request-body-validator.test.ts
@@ -66,7 +66,7 @@ describe('RequestBodyValidator', () => {
       'Warning: This array was found to be empty and therefore could not be validated. Path: requestBody -> example -> classes',
     );
     expect(warnings).toContainValidationWarning(
-      'Warning: Response object is missing non-required properties that were unable to be validated, including hobby. Path: requestBody -> example',
+      'Warning: Request body is missing non-required properties that were unable to be validated, including hobby. Path: requestBody -> example',
     );
   });
 });


### PR DESCRIPTION
Add request body missing optional properties warning message to distinguish when a request body and when a response is missing optional properties