### PR TITLE
API-28247 Fixes to prevent the ugly error message and 

### DIFF
--- a/src/suites/positive/validation/positive-validator.ts
+++ b/src/suites/positive/validation/positive-validator.ts
@@ -169,8 +169,15 @@ abstract class PositiveValidator extends BaseValidator {
     schema?: OASSchema,
   ): Promise<{ [property: string]: SchemaObject } | undefined> {
     if (expected.$ref && schema) {
-      const resolvePath = expected.$ref.split('/');
+      // The reference string may contain a URL before the path, but we're only interested in the path.
+      // So, anything left of the # char is removed.
+      let reference = expected.$ref;
+      const hashPosition = reference.indexOf('#');
+      if (hashPosition >= 0) {
+        reference = reference.substring(hashPosition);
+      }
 
+      const resolvePath = reference.split('/');
       if (resolvePath.length > 0 && resolvePath[0] === '#') {
         resolvePath.shift();
       }
@@ -182,7 +189,7 @@ abstract class PositiveValidator extends BaseValidator {
       );
 
       if (resolvedElement) {
-        return resolvedElement.spec.properties;
+        return resolvedElement.spec?.properties;
       }
     }
 


### PR DESCRIPTION
deal with the root cause
Updated swagger dereferencing logic to handle situations where component references have OAS base path string injected into front of #path.  Previous logic would fail and show "Cannot read properties of null (reading 'properties')" since this would cause references to components that did not exist