### PR TITLE
[API-28925] Update Jenkinsfile to use node from GHCR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 pipeline {
   agent {
     docker {
-      image 'vasdvp/lighthouse-node-application-base:node16'
+      image 'ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16'
+      registryUrl 'https://ghcr.io'
+      registryCredentialsId 'GITHUB_USERNAME_TOKEN'
     }
   }
   environment {


### PR DESCRIPTION
Updated Jenkinsfile to use the node image from GHCR instead of dockerhub