### PR TITLE
API-29864 add rules for api standards boolean naming

### DIFF
--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -6,9 +6,8 @@ rules:
     description: Booleans should be prefixed with an auxiliary verb (such as is, has, or can).
     message: '`{{property}}` is not prefixed with an auxiliary verb'
     severity: warn
-    given: $..properties
+    given: $..properties.[?(@.type === "boolean")]~
     then:
-      type: boolean
       function: pattern
       functionOptions:
         match: /^(is|has|can).+$/i

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -4,7 +4,7 @@ rules:
 
   va-property-names-booleans:
     description: Booleans should be prefixed with an auxiliary verb (such as is, has, or can).
-    message: '`{{property}}` is not prefixed with an auxiliary verb'
+    message: '`{{property}}` is not prefixed with an auxiliary verb (e.g. "veteran" becomes "isVeteran")'
     severity: warn
     given: $..properties.[?(@.type === "boolean")]~
     then:

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -2,6 +2,17 @@ extends: 'spectral:oas'
 rules:
   operation-tag-defined: off
 
+  va-property-names-booleans:
+    description: Booleans should be prefixed with an auxiliary verb (such as is, has, or can).
+    message: '`{{property}}` is not prefixed with an auxiliary verb'
+    severity: warn
+    given: $..properties
+    then:
+      type: boolean
+      function: pattern
+      functionOptions:
+        match: /^(is|has|can).+$/i
+
   va-property-names-camel-case:
     description: Property names should be written in camelCase.
     message: '`{{property}}` is not camelCase'

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -14,7 +14,7 @@
     },
     "lighthouse-api-standards" : {
         "va-endpoint-operation-security": ["Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {})."],
-        "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb", "`claims` is not prefixed with an auxiliary verb", "`access` is not prefixed with an auxiliary verb"],
+        "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -14,6 +14,7 @@
     },
     "lighthouse-api-standards" : {
         "va-endpoint-operation-security": ["Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {})."],
+        "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb", "`claims` is not prefixed with an auxiliary verb", "`access` is not prefixed with an auxiliary verb"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/va-property-names-booleans-fail.json
+++ b/test/suites/rulesets/fixtures/va-property-names-booleans-fail.json
@@ -1,0 +1,46 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "get":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "veteran": {
+                                        "type": "boolean",
+                                        "description": "boolean property not prefixed with is",
+                                        "example":	true
+                                    },
+                                    "claims": {
+                                        "type": "boolean",
+                                        "description": "boolean property not prefixed with has",
+                                        "example":	true
+                                    },
+                                    "access": {
+                                        "type": "boolean",
+                                        "description": "boolean property not prefixed with can",
+                                        "example":	false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}

--- a/test/suites/rulesets/fixtures/va-property-names-booleans-pass.json
+++ b/test/suites/rulesets/fixtures/va-property-names-booleans-pass.json
@@ -1,0 +1,46 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "get":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "isVeteran": {
+                                        "type": "boolean",
+                                        "description": "boolean property prefixed with is",
+                                        "example":	true
+                                    },
+                                    "hasClaims": {
+                                        "type": "boolean",
+                                        "description": "boolean property prefixed with has",
+                                        "example":	true
+                                    },
+                                    "canAccess": {
+                                        "type": "boolean",
+                                        "description": "boolean property prefixed with can",
+                                        "example":	false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}


### PR DESCRIPTION
Adds rules to check OAS for [proper naming of booleans](https://department-of-veterans-affairs.github.io/lighthouse-api-standards/naming-and-formatting/#booleans)