### PR TITLE
API 30596: API standards ruleset enum values upper case

### DIFF
--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -32,7 +32,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: /^[A-Z]+(?:_[A-Z]+)*$/
+        match: /^[A-Z]+[A-Z0-9]+(?:_[A-Z0-9]+)*$/
 
   va-endpoint-operation-security:
     description: Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {}).

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -24,6 +24,16 @@ rules:
       functionOptions:
         type: camel
 
+  va-property-enum-values-upper-case:
+    description: Enums should be UPPER_CASE strings with underscores in place of spaces.
+    message: Enums should be UPPER_CASE strings with underscores in place of spaces.
+    severity: warn
+    given: $..properties..enum[*]
+    then:
+      function: pattern
+      functionOptions:
+        match: /^[A-Z]+(?:_[A-Z]+)*$/
+
   va-endpoint-operation-security:
     description: Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {}).
     given: $.paths.[*].[get,post,put,patch,delete]

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -16,6 +16,7 @@
         "va-endpoint-operation-security": ["Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {})."],
         "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
+        "va-property-enum-values-upper-case": ["Enums should be UPPER_CASE strings with underscores in place of spaces."],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],
         "va-endpoint-default-errors-forbidden": ["A response with error status code 403 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/va-property-enum-values-upper-case-fail.json
+++ b/test/suites/rulesets/fixtures/va-property-enum-values-upper-case-fail.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "trainingType": {
+                                        "type": "string",
+                                        "example": "underGrad",
+                                        "enum": [
+                                            "underGrad"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}

--- a/test/suites/rulesets/fixtures/va-property-enum-values-upper-case-pass.json
+++ b/test/suites/rulesets/fixtures/va-property-enum-values-upper-case-pass.json
@@ -1,0 +1,38 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "trainingType": {
+                                        "type": "string",
+                                        "example": "UNDER_GRAD",
+                                        "enum": [
+                                            "UNDER_GRAD"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}


### PR DESCRIPTION
Adds a rule to check enum values.
Enums should be UPPER_CASE strings with underscores in place of spaces. API Standards - [naming and formatting](https://department-of-veterans-affairs.github.io/lighthouse-api-standards/naming-and-formatting/#naming-formatting)