### PR TITLE
Api 31331 api standards ruleset dates format

### DIFF
--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -34,6 +34,16 @@ rules:
       functionOptions:
         match: /^[A-Z]+[A-Z0-9]+(?:_[A-Z0-9]+)*$/
 
+  va-property-date-format:
+    description: Dates must follow the format YYYY-MM-DD or YYYY-MM
+    message: Dates must follow the format YYYY-MM-DD or YYYY-MM
+    severity: error
+    given: $..properties.[?(@.format == "date")].example
+    then:
+      function: pattern
+      functionOptions:
+        match: /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$|([12]\d{3}-(0[1-9]|1[0-2]))$/
+
   va-endpoint-operation-security:
     description: Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {}).
     given: $.paths.[*].[get,post,put,patch,delete]

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -17,7 +17,7 @@
         "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-property-enum-values-upper-case": ["Enums should be UPPER_CASE strings with underscores in place of spaces."],
-        "va-property-date-format": ["Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM"],
+        "va-property-date-format": ["Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM"],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],
         "va-endpoint-default-errors-forbidden": ["A response with error status code 403 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -17,6 +17,7 @@
         "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-property-enum-values-upper-case": ["Enums should be UPPER_CASE strings with underscores in place of spaces."],
+        "va-property-date-format": ["Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM"],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],
         "va-endpoint-default-errors-forbidden": ["A response with error status code 403 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/va-property-date-format-fail.json
+++ b/test/suites/rulesets/fixtures/va-property-date-format-fail.json
@@ -1,0 +1,43 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                   "claimDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YY-MM-DD format",
+                                        "example": "23-06-04"
+                                    },
+                                    "closeDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YY/MM format",
+                                        "example": "19-09"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}

--- a/test/suites/rulesets/fixtures/va-property-date-format-fail.json
+++ b/test/suites/rulesets/fixtures/va-property-date-format-fail.json
@@ -26,8 +26,20 @@
                                     "closeDate": {
                                         "format": "date",
                                         "type": "string",
-                                        "description": "Date in YY/MM format",
+                                        "description": "Date in YY-MM format",
                                         "example": "19-09"
+                                    },
+                                    "someDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YYYY/MM/DD format",
+                                        "example": "1999/09/20"
+                                    },
+                                    "anotherDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YYYY/MM format",
+                                        "example": "1984/09"
                                     }
                                 }
                             }

--- a/test/suites/rulesets/fixtures/va-property-date-format-pass.json
+++ b/test/suites/rulesets/fixtures/va-property-date-format-pass.json
@@ -1,0 +1,43 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                   "claimDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YYYY-MM-DD format",
+                                        "example": "2018-06-04"
+                                    },
+                                    "closeDate": {
+                                        "format": "date",
+                                        "type": "string",
+                                        "description": "Date in YYYY-MM format",
+                                        "example": "2019-09"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}


### PR DESCRIPTION
Adds a rule to check date formats.
Dates must follow the ISO 8601 standard. The accepted formats are YYYY-MM-DD or YYYY-MM. 
API Standards - [Dates and Time](https://department-of-veterans-affairs.github.io/lighthouse-api-standards/naming-and-formatting/dates/#dates-time)