### PR TITLE
[API-28168] Add an end to end test for positive suite

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@
 /bin
 /**/fixtures/**/*
 jest.config.js
+jest.e2e.config.js
 .eslintrc.js
 /@types

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   testPathIgnorePatterns: ['/node_modules/', '/lib/', '/test/lib-test/'],
   testEnvironment: 'node',
-  testRegex: '(/__tests__/.*|(\\.|/)(test|spec|integration))\\.[jt]s?$',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec|integration|e2e))\\.[jt]s?$',
   testTimeout: 20000, // milliseconds
   setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,19 +2,22 @@ module.exports = {
   testResultsProcessor: './node_modules/jest-junit-reporter',
   preset: 'ts-jest',
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      diagnostics: false,
-    }]
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        diagnostics: false,
+      },
+    ],
   },
-  coveragePathIgnorePatterns: ["/node_modules/", "/lib/", "/test/lib-test/"],
+  coveragePathIgnorePatterns: ['/node_modules/', '/lib/', '/test/lib-test/'],
   coverageThreshold: {
     '**/*.ts': {
       statements: 80,
     },
   },
-  testPathIgnorePatterns: ['/node_modules/', '/lib/', "/test/lib-test/"],
+  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/test/lib-test/'],
   testEnvironment: 'node',
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec|integration))\\.[jt]s?$',
   testTimeout: 20000, // milliseconds
-  setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts']
+  setupFilesAfterEnv: ['<rootDir>/test/setup-tests.ts'],
 };

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,5 @@
+const config = require('./jest.config');
+
+config.testRegex = '(/__tests__/.*|(\\.|/)(e2e))\\.[jt]s?$';
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && cp ./src/suites/rulesets/*.yaml ./lib/suites/rulesets && oclif manifest && oclif readme",
     "test": "npm run build:tests && jest",
+    "test:e2e": "npm run build:tests && jest -c jest.e2e.config.js",
     "test:ci": "npm run build:tests && jest --coverage",
     "test:clear": "jest --clearCache",
     "test:debug": "npm run build:tests && node --inspect node_modules/.bin/jest --runInBand",

--- a/test/fixtures/oas/e2e/example_group_validator.json
+++ b/test/fixtures/oas/e2e/example_group_validator.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Example Group Validator E2E OAS",
+    "description": "E2E test OAS that contains errors that should be caught by the exampleGroupValidator",
+    "contact": {
+      "name": "developer.va.gov"
+    },
+    "version": "0.0.1"
+  },
+  "servers": [
+    {
+      "url": "https://example.com/services/example_group_validator/{version}",
+      "description": "Sandbox",
+      "variables": {
+        "version": {
+          "default": "v0"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "example-group-validator",
+      "description": "Example Group Validator E2E test"
+    }
+  ],
+  "paths": {
+    "/example_group_validator": {
+      "get": {
+        "tags": ["example-group-validator"],
+        "summary": "Summary",
+        "description": "Description",
+        "operationId": "getInvalidExampleGroups",
+        "parameters": [
+          {
+            "name": "missing_parameter",
+            "in": "query",
+            "description": "Missing parameter",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "missing_parameter": {}
+            }
+          },
+          {
+            "name": "mismatched_string_parameter",
+            "in": "query",
+            "description": "Parameter with the wrong type",
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "mismatched_parameter": {
+                "value": 1234
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {}
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "OAuth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://example.com/oauth2/example-group-validator/system/v1/token",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/suites/positive/positive-suite.e2e.ts
+++ b/test/suites/positive/positive-suite.e2e.ts
@@ -1,0 +1,60 @@
+import Suites from '../../../src/commands/suites';
+import SwaggerClient from 'swagger-client';
+import PositiveSuite from '../../../src/suites/positive/positive-suite';
+
+describe('ExampleGroupValidator', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  SwaggerClient.prototype.execute = jest.fn((options) => {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      url: options.server,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  });
+
+  it('passes with valid parameters', async () => {
+    const conduct = jest.spyOn(PositiveSuite.prototype, 'conduct');
+    await Suites.run([
+      'test/fixtures/oas/example_groups_oas.json',
+      '-s',
+      'https://sandbox-api.va.gov/services/va_facilities/{version}',
+      '-b',
+      'test_token',
+      '-i',
+      'positive',
+    ]);
+
+    expect(conduct).toHaveBeenCalledTimes(1);
+
+    const results = await conduct.mock.results[0].value;
+    const failures = results.filter((result) => result.failures.size > 0);
+    expect(failures.length).toEqual(0);
+  });
+
+  it('fails with invalid parameters', async () => {
+    const conduct = jest.spyOn(PositiveSuite.prototype, 'conduct');
+    await Suites.run([
+      'test/fixtures/oas/e2e/example_group_validator.json',
+      '-s',
+      'https://example.com/services/example_group_validator/{version}',
+      '-b',
+      'test_token',
+      '-i',
+      'positive',
+    ]);
+
+    expect(conduct).toHaveBeenCalledTimes(1);
+
+    const expectedFailures = ['missing_parameter', 'mismatched_parameter'];
+    const results = await conduct.mock.results[0].value;
+    const failures = results.filter((result) => result.failures.size > 0);
+    const failedTestGroups = failures.map((failure) => failure.testGroupName);
+    expect(failedTestGroups).toEqual(expectedFailures);
+  });
+});

--- a/test/suites/positive/positive-suite.e2e.ts
+++ b/test/suites/positive/positive-suite.e2e.ts
@@ -3,8 +3,18 @@ import SwaggerClient from 'swagger-client';
 import PositiveSuite from '../../../src/suites/positive/positive-suite';
 
 describe('ExampleGroupValidator', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    // Suppress console output from Suites.run() to avoid cluttering test output
+    logSpy = jest.spyOn(Suites.prototype, 'log').mockImplementation(() => {
+      return;
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+    logSpy.mockRestore();
   });
 
   SwaggerClient.prototype.execute = jest.fn((options) => {


### PR DESCRIPTION
Adding an end to end test command for the loast positive suite. E2E tests can be run using `npm run test:e2e`. This PR only includes the end to end test for example group validator-- other validator tests will be added in the future.