### PR TITLE
API-31346 API Standards Ruleset: Timestamps Correct Format

### DIFF
--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -52,7 +52,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))(T[0-2]\d:[0-5]\d:[0-5]\d([0-2]\d:[0-5]\d|Z))$/
+        match: /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))(T[0-2]\d:[0-5]\d:[0-5]\dZ)$/
 
   va-endpoint-operation-security:
     description: Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {}).

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -44,6 +44,16 @@ rules:
       functionOptions:
         match: /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$|(\d{4}-(0[1-9]|1[0-2]))$/
 
+  va-property-date-time-format:
+    description: Timestamps must be in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ
+    message: Timestamps must be in ISO 8601 format "YYYY-MM-DDTHH:MM:SSZ"
+    severity: error
+    given: $..properties.[?(@.format == "date-time")].example
+    then:
+      function: pattern
+      functionOptions:
+        match: /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))(T[0-2]\d:[0-5]\d:[0-5]\d([0-2]\d:[0-5]\d|Z))$/
+
   va-endpoint-operation-security:
     description: Security must be declared for each operation. If this endpoint does not require authentication set the security object to an array with one blank object (- {}).
     given: $.paths.[*].[get,post,put,patch,delete]

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -17,6 +17,7 @@
         "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-property-enum-values-upper-case": ["Enums should be UPPER_CASE strings with underscores in place of spaces."],
+        "va-property-date-time-format": ["Timestamps must be in ISO 8601 format \"YYYY-MM-DDTHH:MM:SSZ\"", "Timestamps must be in ISO 8601 format \"YYYY-MM-DDTHH:MM:SSZ\""],
         "va-property-date-format": ["Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM", "Dates must follow the format YYYY-MM-DD or YYYY-MM"],
         "va-endpoint-default-errors-bad-request": ["A response with error status code 400 is required for all endpoints."],
         "va-endpoint-default-errors-unauthorized": ["A response with error status code 401 is required for all endpoints."],

--- a/test/suites/rulesets/fixtures/va-property-date-time-format-fail.json
+++ b/test/suites/rulesets/fixtures/va-property-date-time-format-fail.json
@@ -1,0 +1,43 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                   "someDateTime": {
+                                        "format": "date-time",
+                                        "type": "string",
+                                        "description": "Timestamp not in ISO 8601 format",
+                                        "example": "2018-06-04T08:00:00"
+                                    },
+                                    "anotherDateTime": {
+                                        "format": "date-time",
+                                        "type": "string",
+                                        "description": "Timestamp not in ISO 8601 format",
+                                        "example": "2018-06-0408:00:00"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}

--- a/test/suites/rulesets/fixtures/va-property-date-time-format-pass.json
+++ b/test/suites/rulesets/fixtures/va-property-date-time-format-pass.json
@@ -1,0 +1,37 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+    },
+    "tags": [
+    ],
+    "paths": {
+        "/onePathExist": {
+            "post":{ 
+                "tags": [],
+                "summary": "",
+                "description": "",
+                "requestBody": {
+                    "description": "",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                   "someDateTime": {
+                                        "format": "date-time",
+                                        "type": "string",
+                                        "description": "Timestamp in ISO 8601 format",
+                                        "example": "2018-06-04T08:00:00Z"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {}
+            }
+        }
+    },
+    "components": {
+    }
+}


### PR DESCRIPTION
Adds a rule to check timestamp (date-time) formats.
Timestamps must be in ISO 8601 format YYYY-MM-DDTHH:MM:SSZ e.g. 2022-10-03T09:00:00Z
API Standards - [Timestamps](https://department-of-veterans-affairs.github.io/lighthouse-api-standards/naming-and-formatting/dates/#timestamps)