### PR TITLE
API-32623: change regex that was causing some OASs to not complete

### DIFF
--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -151,4 +151,4 @@ rules:
     then:
       function: pattern
       functionOptions:
-        notMatch: /(http:\/\/|https:\/\/)?([\-\][a-z0-9]+)*?(developer\.va\.gov)/ig
+        notMatch: /(https?:\/\/)?([-][a-z0-9]+)*(developer\.va\.gov)/ig


### PR DESCRIPTION
Some OAS's were failing to complete this test in a timely manner.  This change seems to fix it. Just removing the slashes around the dash fixed it, the other changes are just some cleanup.