### PR TITLE
Revert node 20 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@oclif/core": "^2.16.0",
         "@stoplight/spectral-core": "^1.19.4",
-        "@stoplight/spectral-ruleset-bundler": "^1.6.3",
+        "@stoplight/spectral-ruleset-bundler": "^1.5.2",
         "content-type": "^1.0.5",
         "js-yaml": "^4.1.0",
         "load-json-file": "^6.2.0",
@@ -31,7 +31,7 @@
         "@types/content-type": "^1.1.3",
         "@types/jest": "^28.1.1",
         "@types/lodash": "^4.14.165",
-        "@types/node": "^20.0.0",
+        "@types/node": "^10.17.44",
         "@typescript-eslint/eslint-plugin": "^2.6.1",
         "@typescript-eslint/parser": "^2.6.1",
         "cz-conventional-changelog": "^3.3.0",
@@ -3700,6 +3700,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/plugin-not-found/node_modules/@types/node": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@oclif/plugin-not-found/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -3771,6 +3783,15 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@oclif/plugin-not-found/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@oclif/plugin-warn-if-update-available": {
       "version": "3.1.33",
@@ -6838,18 +6859,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
-      "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -23488,6 +23500,17 @@
             "wrap-ansi": "^7.0.0"
           }
         },
+        "@types/node": {
+          "version": "24.10.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+          "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "undici-types": "~7.16.0"
+          }
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -23529,6 +23552,14 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
           "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
+        },
+        "undici-types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+          "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -25649,7 +25680,7 @@
         "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
         "@types/ramda": "~0.30.0",
-        "axios": ">=1.12.0",
+        "axios": ">=1.7.4",
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
         "ramda": "~0.30.0",
@@ -25853,19 +25884,9 @@
       }
     },
     "@types/node": {
-      "version": "20.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
-      "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
-      "requires": {
-        "undici-types": "~6.21.0"
-      },
-      "dependencies": {
-        "undici-types": {
-          "version": "6.21.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
-        }
-      }
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@oclif/core": "^2.16.0",
     "@stoplight/spectral-core": "^1.19.4",
-    "@stoplight/spectral-ruleset-bundler": "^1.6.3",
+    "@stoplight/spectral-ruleset-bundler": "^1.5.2",
     "content-type": "^1.0.5",
     "js-yaml": "^4.1.0",
     "load-json-file": "^6.2.0",
@@ -26,7 +26,7 @@
     "@types/content-type": "^1.1.3",
     "@types/jest": "^28.1.1",
     "@types/lodash": "^4.14.165",
-    "@types/node": "^20.0.0",
+    "@types/node": "^10.17.44",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "cz-conventional-changelog": "^3.3.0",
@@ -43,7 +43,7 @@
     "typescript": "^5.1.3"
   },
   "overrides": {
-    "axios": ">=1.12.0",
+    "axios": ">=1.7.4",
     "rollup": ">=3.29.5",
     "cross-spawn": "^7.0.3",
     "jsonpath-plus": ">=10.3.0"


### PR DESCRIPTION
Reverted the following changes to prepare for Node 18 upgrade:
- @types/node: ^20.0.0 -> ^10.17.44
- @stoplight/spectral-ruleset-bundler: ^1.6.3 -> ^1.5.2
- axios: >=1.12.0 -> >=1.7.4

Regenerated package-lock.json with npm install