### PR TITLE
Fix/api 50317 Add new security rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@oclif/core": "^2.16.0",
         "@stoplight/spectral-core": "^1.19.4",
-        "@stoplight/spectral-ruleset-bundler": "^1.5.2",
+        "@stoplight/spectral-ruleset-bundler": "^1.6.3",
         "content-type": "^1.0.5",
         "js-yaml": "^4.1.0",
         "load-json-file": "^6.2.0",
@@ -25680,7 +25680,7 @@
         "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1",
         "@types/ramda": "~0.30.0",
-        "axios": ">=1.7.4",
+        "axios": ">=1.12.0",
         "minimatch": "^7.4.3",
         "process": "^0.11.10",
         "ramda": "~0.30.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@oclif/core": "^2.16.0",
     "@stoplight/spectral-core": "^1.19.4",
-    "@stoplight/spectral-ruleset-bundler": "^1.5.2",
+    "@stoplight/spectral-ruleset-bundler": "^1.6.3",
     "content-type": "^1.0.5",
     "js-yaml": "^4.1.0",
     "load-json-file": "^6.2.0",
@@ -43,7 +43,7 @@
     "typescript": "^5.1.3"
   },
   "overrides": {
-    "axios": ">=1.7.4",
+    "axios": ">=1.12.0",
     "rollup": ">=3.29.5",
     "cross-spawn": "^7.0.3",
     "jsonpath-plus": ">=10.3.0"

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -71,7 +71,7 @@ rules:
       field: 'security'
       function: truthy
 
-    va-security-root-level-empty-objects:
+  va-security-root-level-empty-objects:
     description: The "security" array at the root level must not contain empty objects.
     given: $.security[*]
     severity: error

--- a/src/suites/rulesets/lighthouse-api-standards.yaml
+++ b/src/suites/rulesets/lighthouse-api-standards.yaml
@@ -71,6 +71,15 @@ rules:
       field: 'security'
       function: truthy
 
+    va-security-root-level-empty-objects:
+    description: The "security" array at the root level must not contain empty objects.
+    given: $.security[*]
+    severity: error
+    then:
+      function: length
+      functionOptions:
+        min: 1
+
   va-endpoint-default-errors-bad-request:
     description: A response with error status code 400 is required for all endpoints.
     given: $.paths..responses

--- a/test/suites/rulesets/fixtures/setup.json
+++ b/test/suites/rulesets/fixtures/setup.json
@@ -15,6 +15,7 @@
     "lighthouse-api-standards" : {
         "va-endpoint-operation-security": ["The \"security\" array at endpoint operation must not contain empty objects."],
         "va-openapidoc-root-level-security": ["Security is not applied at the root level (globally)."],
+        "va-security-root-level-empty-objects": ["The \"security\" array at the root level must not contain empty objects."],
         "va-property-names-booleans": ["`veteran` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`claims` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")", "`access` is not prefixed with an auxiliary verb (e.g. \"veteran\" becomes \"isVeteran\")"],
         "va-property-names-camel-case": ["`street_address_1` is not camelCase", "`street_address_2` is not camelCase", "`street_address_3` is not camelCase"],
         "va-property-enum-values-upper-case": ["Enums should be UPPER_CASE strings with underscores in place of spaces."],

--- a/test/suites/rulesets/fixtures/va-security-root-level-empty-objects-fail.json
+++ b/test/suites/rulesets/fixtures/va-security-root-level-empty-objects-fail.json
@@ -1,0 +1,10 @@
+{
+    "openapi": "3.0.1",
+    "info": {},
+    "tags": [],
+    "security": [
+        {}
+    ],
+    "paths": {},
+    "components": {}
+}

--- a/test/suites/rulesets/fixtures/va-security-root-level-empty-objects-pass.json
+++ b/test/suites/rulesets/fixtures/va-security-root-level-empty-objects-pass.json
@@ -1,0 +1,12 @@
+{
+    "openapi": "3.0.1",
+    "info": {},
+    "tags": [],
+    "security": [
+        {
+            "apikey": []
+        }
+    ],
+    "paths": {},
+    "components": {}
+}


### PR DESCRIPTION
## Description
This PR adds a new security validation rule and upgrades dependencies to resolve security vulnerabilities.

## Changes Made

### New Security Rule
- **Added `va-security-root-level-empty-objects` rule** to validate that the root-level `security` array does not contain empty objects
- Ensures all security definitions specify actual authentication schemes
- Severity: Error (fails validation if violated)
- Target: `$.security[*]` - each security object in the root-level security array
- Added test fixtures for pass/fail scenarios

### Dependency Updates
- **Updated `@stoplight/spectral-ruleset-bundler`**: `1.5.2` → `1.6.3`
  - Resolves rollup vulnerability by upgrading to `rollup@4.22.4`
- **Updated `axios` override**: `>=1.7.4` → `>=1.12.0`
  - Resolves DoS vulnerability (CVE-2025-58754)

## Testing
- ✅ All 255 tests passing
- ✅ Build successful
- ✅ Linting passed
- ✅ New security rule validated with both fail and pass test cases
